### PR TITLE
Fixed css minification issues

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -26,3 +26,4 @@ nathantreid:css-modules
 dburles:factory
 practicalmeteor:sinon
 omega:dirty-chai
+hasse:tachyons

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -36,6 +36,7 @@ email@1.2.3
 es5-shim@4.6.15
 fastclick@1.0.13
 geojson-utils@1.0.10
+hasse:tachyons@1.0.0
 hot-code-push@1.0.4
 html-tools@1.0.11
 htmljs@1.0.11

--- a/client/main.css
+++ b/client/main.css
@@ -1,1 +1,4 @@
-@import 'tachyons/src/tachyons.css';
+/* Tachyons fixes and overrides */
+.b--transparent {
+  border-color: transparent;
+}

--- a/package.json
+++ b/package.json
@@ -37,9 +37,8 @@
     "react-addons-test-utils": "^15.6.0",
     "react-test-renderer": "^15.6.1",
     "snazzy": "^7.0.0",
-    "standard": "^10.0.2",
-    "tachyons": "^4.7.0",
-    "spacejam": "^1.6.1"
+    "spacejam": "^1.6.1",
+    "standard": "^10.0.2"
   },
   "cssModules": {
     "cssClassNamingConvention": {


### PR DESCRIPTION
Fixes #2 
I removed the npm dependency for tachyons, and added an atmosphere dependency for it.
I think importing css files from NPM packages doesn't work well with the tools that we're using, so this is an alternative even though it means we're using an older version of tachyons.