### PR TITLE
fix: use BZ username on signup

### DIFF
--- a/imports/api/hooks/on-create-user.js
+++ b/imports/api/hooks/on-create-user.js
@@ -32,7 +32,7 @@ export function onCreateUser (options, user) {
 
   let loginResult
   try {
-    loginResult = callAPI('get', '/rest/login', {login: email, password}, false, true)
+    loginResult = callAPI('get', '/rest/login', {login: bzLogin || email, password}, false, true)
   } catch (e) {
     console.error(e)
     throw new Meteor.Error({message: 'REST API error', origError: e})

--- a/imports/api/hooks/on-create-user.test.js
+++ b/imports/api/hooks/on-create-user.test.js
@@ -86,7 +86,7 @@ if (Meteor.isServer) {
 
         expect(boundFunc).to.throw()
         expect(callAPIStub).to.have.been.calledOnce()
-        expect(callAPIStub).to.have.been.calledWith('get', '/rest/login', sinon.match({ login: fakeEmail, password: sinon.match.string }), false, true)
+        expect(callAPIStub).to.have.been.calledWith('get', '/rest/login', sinon.match({ login: bzLogin, password: sinon.match.string }), false, true)
       })
 
       it('should not store the password on the bugzillaCreds object if bzLogin and bzPass are provided', () => {

--- a/imports/util/bugzilla-api.test.js
+++ b/imports/util/bugzilla-api.test.js
@@ -8,6 +8,7 @@ import { callAPI } from './bugzilla-api'
 
 if (Meteor.isServer) {
   describe('bugzilla-api Util', () => {
+    const base = process.env.BUGZILLA_URL || 'http://localhost:8081'
     let origBugzillaUrl, origBugzillaKey
     beforeEach(() => {
       sinon.stub(HTTP, 'call')
@@ -31,13 +32,13 @@ if (Meteor.isServer) {
       const params = {param1: 1}
       callAPI('get', '/some-route', params)
 
-      expect(HTTP.call).to.have.been.calledWith('get', 'http://localhost:8081/some-route', sinon.match({params: params}), sinon.match.func)
+      expect(HTTP.call).to.have.been.calledWith('get', `${base}/some-route`, sinon.match({params: params}), sinon.match.func)
     })
     it('should call HTTP.call with the appropriate method and params, when using anything other than GET', () => {
       const params = {param1: 1}
       callAPI('post', '/dummy', params)
 
-      expect(HTTP.call).to.have.been.calledWith('post', 'http://localhost:8081/dummy', sinon.match({data: params}), sinon.match.func)
+      expect(HTTP.call).to.have.been.calledWith('post', `${base}/dummy`, sinon.match({data: params}), sinon.match.func)
     })
     it('should use the bugzilla server path from the env var, if specified', () => {
       process.env.BUGZILLA_URL = 'https://bla.bugzilla.unee-t.net'


### PR DESCRIPTION
Allow sign up with a Bugzilla username that is different from the Meteor username.

Also includes test fix to support `BUGZILLA_URL` environment variable.