### PR TITLE
feat: Display Open/closed cases in Unit Cases

### DIFF
--- a/imports/api/cases.js
+++ b/imports/api/cases.js
@@ -40,6 +40,8 @@ export const caseServerFieldMapping = {
   resolution: 'resolution'
 }
 
+export const isClosed = caseItem => ['RESOLVED', 'VERIFIED', 'CLOSED'].includes(caseItem.status)
+
 export const caseClientFieldMapping = Object.assign(
   Object.keys(caseServerFieldMapping).reduce((all, key) => ({
     ...all,

--- a/imports/ui/case-explorer/case-explorer.jsx
+++ b/imports/ui/case-explorer/case-explorer.jsx
@@ -11,13 +11,12 @@ import Cases, { collectionName } from '../../api/cases'
 import { push } from 'react-router-redux'
 import RootAppBar from '../components/root-app-bar'
 import { storeBreadcrumb } from '../general-actions'
+import { isClosed } from '../../api/cases'
 
 import {
   unitIconsStyle,
   moreIconColor
 } from './case-explorer.mui-styles'
-
-const isClosed = caseItem => ['RESOLVED', 'VERIFIED', 'CLOSED'].includes(caseItem.status)
 
 class CaseExplorer extends Component {
   constructor () {

--- a/imports/ui/unit/unit.jsx
+++ b/imports/ui/unit/unit.jsx
@@ -21,11 +21,6 @@ import { userInfoItem } from '../../util/user'
 import { storeBreadcrumb } from '../general-actions'
 import { isClosed } from '../../api/cases'
 
-// const CASE_STATUS = Object.freeze({
-//   OPEN: 0,
-//   CLOSED: 1,
-// });
-
 const viewsOrder = ['cases', 'reports', 'overview']
 
 const severityIcons = {
@@ -61,34 +56,33 @@ class Unit extends Component {
     super(...arguments)
     this.state = {
       sortedCases: [],
-      showOpenCases: true 
+      showOpenCases: true
     }
-
   }
 
-  get openCases() {
-    const { sortedCases } = this.state;
-    return sortedCases.filter(x => !isClosed(x)); 
+  get openCases () {
+    const { sortedCases } = this.state
+    return sortedCases.filter(x => !isClosed(x))
   }
 
-  get closedCases() {
-    const { sortedCases } = this.state;
-    return sortedCases.filter(x => isClosed(x));
+  get closedCases () {
+    const { sortedCases } = this.state
+    return sortedCases.filter(x => isClosed(x))
   }
 
-  get filteredCases() {
-    const { showOpenCases } = this.state;
+  get filteredCases () {
+    const { showOpenCases } = this.state
     if (showOpenCases) {
-      return this.openCases; 
+      return this.openCases
     } else {
-      return this.closedCases; 
+      return this.closedCases
     }
   }
-   
+
   handleOpenClicked = () => {
     this.setState({ showOpenCases: true })
   }
-  
+
   handleClosedClicked = () => {
     this.setState({ showOpenCases: false })
   }
@@ -110,8 +104,8 @@ class Unit extends Component {
   }
   render () {
     const { unitItem, isLoading, unitError, casesError, unitUsers, dispatch, match } = this.props
-    const { sortedCases, showOpenCases } = this.state;
-    const { filteredCases } = this; 
+    const { sortedCases, showOpenCases } = this.state
+    const { filteredCases } = this
 
     const rootMatch = match
 
@@ -167,12 +161,12 @@ class Unit extends Component {
                 >
 
                   <div className='flex-grow bg-very-light-gray'>
-                   <div className='pl3 pv2 mv1 b--very-light-gray bg-white'>
+                   <div className='pl3 pv3 bb b--very-light-gray bg-white'>
                     <button onClick={this.handleOpenClicked} className={'f6 fw5 ' + (showOpenCases ? 'mid-gray' : 'silver')}>
-                     Open
+                     { this.openCases.length } Open 
                     </button>
-                    <button onClick={this.handleClosedClicked} className={'f6 fw5 ml3 ' + (showOpenCases ? 'silver' : 'mid-gray')}>
-                     Closed
+                    <button onClick={this.handleClosedClicked} className={'f6 fw5 ' + (showOpenCases ? 'silver' : 'mid-gray')}>
+                    { this.closedCases.length } Closed
                     </button>
                    </div>
                     {filteredCases.map(({id, title, severity}) => (

--- a/imports/ui/unit/unit.jsx
+++ b/imports/ui/unit/unit.jsx
@@ -19,6 +19,7 @@ import Preloader from '../preloader/preloader'
 import { infoItemMembers } from '../util/static-info-rendering'
 import { userInfoItem } from '../../util/user'
 import { storeBreadcrumb } from '../general-actions'
+import { isClosed } from '../../api/cases'
 
 const viewsOrder = ['cases', 'reports', 'overview']
 
@@ -57,6 +58,22 @@ class Unit extends Component {
       sortedCases: []
     }
   }
+
+
+  // 2. is this setState correctly updating open/close cases? 
+ openClicked = () => {
+    this.setState(prevState => ({
+      sortedCases: openCases 
+    }));
+  }
+  
+  closedClicked = () => {
+    this.setState(prevState => ({
+      sortedCases: closedCases 
+    }));
+  }
+
+
   handleChange = val => {
     const { match, dispatch } = this.props
     dispatch(push(`${match.url}/${viewsOrder[val]}`))
@@ -76,6 +93,15 @@ class Unit extends Component {
     const { unitItem, isLoading, unitError, casesError, unitUsers, dispatch, match } = this.props
     const { sortedCases } = this.state
 
+    if ( sortedCases.length !== 0 ){
+    const closedCases = sortedCases.filter(x => isClosed(x)); 
+    console.log(sortedCases)
+    const openCases = sortedCases.filter(val => !closedCases.includes(val));
+    const openNum = openCases.length;  
+    console.log("closed cases", closedCases.length);
+    console.log("open cases", openCases.length ); 
+    }
+ 
     const rootMatch = match
 
     if (isLoading) return <Preloader />
@@ -126,7 +152,15 @@ class Unit extends Component {
                   index={viewIdx}
                   onChangeIndex={this.handleChange}
                 >
+
                   <div className='flex-grow bg-very-light-gray'>
+                    <button onClick={this.openClicked}>
+                     Open
+                     {/*  P1: does not display {openCases.length} */}
+                    </button>
+                    <button onClick={this.closedClicked}>
+                     Closed
+                    </button>
                     {sortedCases.map(({id, title, severity}) => (
                       <div key={id} className='bb b--very-light-gray bg-white'>
                         <Link


### PR DESCRIPTION
fixes issue #259. This adds two buttons that display open and closed cases. 

You will see **0 closed** throughout different unit cases examples. This is because isClosed function filters resolved, verified, and closed in case status, while current examples take confirmed, unconfirmed, and standby as case status.  

Thank you ❤️ ❤️ Happy Friday 🌻🌻🌻!! 



