### PR TITLE
Fix npm WARN eslint-plugin-standard@3.0.1 requires a peer of eslint@>…

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "babel-eslint": "^8.0.3",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "enzyme": "^2.9.1",
+    "eslint": "^5.0.0",
     "postcss-easy-import": "^2.1.0",
     "postcss-modules-extract-imports": "^1.1.0",
     "postcss-modules-local-by-default": "^1.2.0",


### PR DESCRIPTION
…=3.19.0 but none is installed. You must install peer dependencies yourself.