### PR TITLE
Notification email verification

### DIFF
--- a/imports/api/custom-users.js
+++ b/imports/api/custom-users.js
@@ -104,6 +104,9 @@ Meteor.methods({
       }, {
         $inc: {
           'receivedInvites.$.accessedCount': 1
+        },
+        $set: {
+          'emails.0.verified': true
         }
       })
       console.log(`${invitedUser.emails[0].address} is using an invitation to access the system`)

--- a/imports/api/hooks/on-login.js
+++ b/imports/api/hooks/on-login.js
@@ -1,11 +1,18 @@
 import { Accounts } from 'meteor/accounts-base'
+import { Meteor } from 'meteor/meteor'
 import randToken from 'rand-token'
 
 // Enforces one-time usage of random generated passwords for newly invited users
 Accounts.onLogin(info => {
-  if (info.type === 'password') {
+  const { user } = info
+  if (info.methodName === 'resetPassword') {
+    Meteor.users.update(user._id, {
+      $set: {
+        'profile.isLimited': false
+      }
+    })
+  } else if (info.type === 'password') {
     console.log('info', info)
-    const { user } = info
     if (user.profile.isLimited) {
       console.log(`resetting the password for ${user.emails[0].address} after one-time usage by invitation`)
       const randPass = randToken.generate(12)

--- a/imports/api/rest/post-process-db-change-message.js
+++ b/imports/api/rest/post-process-db-change-message.js
@@ -96,6 +96,10 @@ export default (req, res) => {
       console.error(`User with bz id ${userId} was not found in mongo`)
       return
     }
+    if (!recipient.emails[0].verified) {
+      console.error(`User with bz id ${userId} has no verified email address, skipping notification`)
+      return
+    }
     if (!recipient.notificationSettings[settingType]) {
       console.log(
         `Skipping ${recipient.bugzillaCreds.login} as opted out from '${settingType}' notifications.`


### PR DESCRIPTION
This gives a stable, yet partial answer to #335, #334 and #331, as well as addressing an issue about users who were originally created by being invited to a case, but then reset their password:
### Previously
After password reset, the new pass would only work once, but then the user's would only be able to login via invitation links, or reset the pass again.
### After the fix
The password reset sets a new stable password. After password reset, invitation links would still work, but won't allow the user to bypass login without entering the new password. (this is a safety measure)