### PR TITLE
Deprecate https://unee-t.com/contact-support/

### DIFF
--- a/imports/ui/side-menu/side-menu.jsx
+++ b/imports/ui/side-menu/side-menu.jsx
@@ -66,21 +66,23 @@ class SideMenu extends Component {
         })}
         <Divider />
         {this.linkDrawerItem({
-          href: 'https://unee-t.com/contact-support/',
+          href: 'mailto:support@unee-t.com?subject=' + window.location.href + '&body=' + encodeURIComponent(`user: ${user.emails[0].address}
+
+What did you expect to do?
+
+### PLEASE FILL IN ###
+          
+What happened?
+
+### PLEASE FILL IN ###
+          
+What should have happened?
+
+### PLEASE FILL IN ###
+
+Please insert any screenshots or error messages that might help us! 🙏`),
           iconName: 'live_help',
-          text: 'Support',
-          isExternal: true
-        })}
-        {this.linkDrawerItem({
-          href: 'https://forum.unee-t.com/',
-          iconName: 'forum',
-          text: 'Forum',
-          isExternal: true
-        })}
-        {this.linkDrawerItem({
-          href: 'https://documentation.unee-t.com',
-          iconName: 'help',
-          text: 'FAQ',
+          text: `Support`,
           isExternal: true
         })}
         <Divider />

--- a/imports/ui/side-menu/side-menu.jsx
+++ b/imports/ui/side-menu/side-menu.jsx
@@ -38,6 +38,22 @@ class SideMenu extends Component {
 
   render () {
     const { user, isDrawerOpen, dispatch } = this.props
+    const supportEmailBody = user && `What were you trying to do?
+
+### PLEASE FILL IN ###
+
+What happened?
+
+### PLEASE FILL IN ###
+
+What should have happened?
+
+### PLEASE FILL IN ###
+
+Please insert any screenshots or error messages that might help us! 🙏
+
+DEBUG INFO:
+user: ${user.emails[0].address}`
     return user ? (
       <Drawer
         docked={false}
@@ -66,23 +82,9 @@ class SideMenu extends Component {
         })}
         <Divider />
         {this.linkDrawerItem({
-          href: 'mailto:support@unee-t.com?subject=' + window.location.href + '&body=' + encodeURIComponent(`user: ${user.emails[0].address}
-
-What did you expect to do?
-
-### PLEASE FILL IN ###
-          
-What happened?
-
-### PLEASE FILL IN ###
-          
-What should have happened?
-
-### PLEASE FILL IN ###
-
-Please insert any screenshots or error messages that might help us! 🙏`),
+          href: 'mailto:support@unee-t.com?subject=' + window.location.href + '&body=' + encodeURIComponent(supportEmailBody),
           iconName: 'live_help',
-          text: `Support`,
+          text: 'Support',
           isExternal: true
         })}
         <Divider />

--- a/imports/ui/side-menu/side-menu.jsx
+++ b/imports/ui/side-menu/side-menu.jsx
@@ -87,6 +87,12 @@ user: ${user.emails[0].address}`
           text: 'Support',
           isExternal: true
         })}
+        {this.linkDrawerItem({
+          href: 'https://documentation.unee-t.com',
+          iconName: 'help',
+          text: 'FAQ',
+          isExternal: true
+        })}
         <Divider />
         {this.routeDrawerItem('/notification-settings', {
           href: '/notification-settings',


### PR DESCRIPTION
Instead of a Web form, a mailto: link is used:

* simpler
* works offline
* can be a more familiar interface
* gets the conversation going

Perhaps the body could have more info like error logs, but I am not sure how to whip them out.