### PR TITLE
Upgrade to 1.7.0.3 for `npm run debug`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ not have access to `AWS_SECRET_ACCESS_KEY`.
 Production deployment on AWS account 1924-5899-3663 is done manually via
 `./deploy.sh -p` via the AWS_PROFILE `aws-prod` only once the **build is tagged**.
 
+# Debugging with VScode
+
+[Background reading](https://github.com/Microsoft/vscode-recipes/blob/master/meteor/README.md#configure-meteor-to-run-in-debug-mode)
+
+* `cd .vscode; curl -O https://media.dev.unee-t.com/2018-07-05/launch.json` for example, edit this to point to where your browser binary lives
+* `npm run debug`... you need to run this manually on the CLI
+* Meteor: Node to attach & debug server side
+* Meteor: Chrome to debug client side
+
 # Logs
 
 Frontend logs to the [meteor log group in

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "start": "meteor run",
     "test": "npm run lint && npm run proof",
+    "debug": "meteor run --inspect",
     "lint": "standard --verbose | snazzy",
     "proof": "TEST_BROWSER_DRIVER=puppeteer meteor test --once --driver-package meteortesting:mocha",
     "test-local": "TEST_WATCH=1 meteor test --driver-package meteortesting:mocha"


### PR DESCRIPTION
https://media.dev.unee-t.com/2018-07-05/launch.json is the launch configuration I am using.

Caveats:
* `npm run debug` manually. running it with vscode doesn't work
* auto-attach in my experience doesn't really work. look at `npm run debug` to verify debugger is attached. vscode's bottom bar should also turn orange
* ui debugging, the [debugger gets confused when multiple chrome profiles are run and often can't attach](https://github.com/Microsoft/vscode-chrome-debug/issues/111) - workaround kill all browsers
* ui debugging, you need to debug the node BEFORE running chrome debugger

More background:
https://github.com/Microsoft/vscode-recipes/blob/master/meteor/README.md#configure-meteor-to-run-in-debug-mode 