### PR TITLE
fix: "+" button for unit 

### DIFF
--- a/imports/ui/unit-explorer/unit-explorer.jsx
+++ b/imports/ui/unit-explorer/unit-explorer.jsx
@@ -56,7 +56,6 @@ class UnitExplorer extends Component {
             </div>
             <div className='absolute bottom-2 right-2'>
               <FloatingActionButton
-                className='bondi-blue'
                 onClick={() => dispatch(push(`/unit/new`))}
               >
                 <FontIcon className='material-icons'>add</FontIcon>

--- a/imports/ui/unit-explorer/unit-explorer.jsx
+++ b/imports/ui/unit-explorer/unit-explorer.jsx
@@ -17,12 +17,6 @@ class UnitExplorer extends Component {
   render () {
     const { isLoading, unitList, dispatch } = this.props
     if (isLoading) return <Preloader />
-    const fabDescriptor =
-      {
-        color: 'var(--bondi-blue)',
-        href: `/unit/new`,
-        icon: 'add'
-      }
 
     return (
       <div className='flex flex-column flex-grow full-height'>
@@ -62,10 +56,10 @@ class UnitExplorer extends Component {
             </div>
             <div className='absolute bottom-2 right-2'>
               <FloatingActionButton
-                backgroundColor={fabDescriptor.color}
-                onClick={() => dispatch(push(fabDescriptor.href))}
+                className='bondi-blue'
+                onClick={() => dispatch(push(`/unit/new`))}
               >
-                <FontIcon className='material-icons'>{fabDescriptor.icon}</FontIcon>
+                <FontIcon className='material-icons'>add</FontIcon>
               </FloatingActionButton>
             </div>
           </div>

--- a/imports/ui/unit-explorer/unit-explorer.jsx
+++ b/imports/ui/unit-explorer/unit-explorer.jsx
@@ -17,13 +17,12 @@ class UnitExplorer extends Component {
   render () {
     const { isLoading, unitList, dispatch } = this.props
     if (isLoading) return <Preloader />
-    const fabDescriptors = [
+    const fabDescriptor =
       {
         color: 'var(--bondi-blue)',
         href: `/unit/new`,
         icon: 'add'
       }
-    ]
 
     return (
       <div className='flex flex-column flex-grow full-height'>
@@ -61,17 +60,14 @@ class UnitExplorer extends Component {
                 ))}
               </div>
             </div>
-            {fabDescriptors.map((desc, ind) => (
-              <div key={ind} className='absolute bottom-2 right-2'>
-                <FloatingActionButton
-                  backgroundColor={desc.color}
-                  className='zoom-effect'
-                  onClick={() => dispatch(push(desc.href))}
-                >
-                  <FontIcon className='material-icons'>{desc.icon}</FontIcon>
-                </FloatingActionButton>
-              </div>
-              ))}
+            <div className='absolute bottom-2 right-2'>
+              <FloatingActionButton
+                backgroundColor={fabDescriptor.color}
+                onClick={() => dispatch(push(fabDescriptor.href))}
+              >
+                <FontIcon className='material-icons'>{fabDescriptor.icon}</FontIcon>
+              </FloatingActionButton>
+            </div>
           </div>
         </div>
       </div>

--- a/imports/ui/unit-explorer/unit-explorer.jsx
+++ b/imports/ui/unit-explorer/unit-explorer.jsx
@@ -11,12 +11,19 @@ import Preloader from '../preloader/preloader'
 import { setDrawerState } from '../general-actions'
 import Units, { collectionName } from '../../api/units'
 import UnitMetaData from '../../api/unit-meta-data'
-import { Link } from 'react-router-dom'
+import FloatingActionButton from 'material-ui/FloatingActionButton'
 
 class UnitExplorer extends Component {
   render () {
     const { isLoading, unitList, dispatch } = this.props
     if (isLoading) return <Preloader />
+    const fabDescriptors = [
+      {
+        color: 'var(--bondi-blue)',
+        href: `/unit/new`,
+        icon: 'add'
+      }
+    ]
 
     return (
       <div className='flex flex-column flex-grow full-height'>
@@ -54,13 +61,17 @@ class UnitExplorer extends Component {
                 ))}
               </div>
             </div>
-            <Link to='/unit/new' className='link'>
-              <MenuItem className='no-shrink' innerDivStyle={{padding: 0}}>
-                <div className='tc bondi-blue fw5 bt b--moon-gray'>
-                  Add Unit
-                </div>
-              </MenuItem>
-            </Link>
+            {fabDescriptors.map((desc, ind) => (
+              <div key={ind} className='absolute bottom-2 right-2'>
+                <FloatingActionButton
+                  backgroundColor={desc.color}
+                  className='zoom-effect'
+                  onClick={() => dispatch(push(desc.href))}
+                >
+                  <FontIcon className='material-icons'>{desc.icon}</FontIcon>
+                </FloatingActionButton>
+              </div>
+              ))}
           </div>
         </div>
       </div>


### PR DESCRIPTION
This adds "+" button docked to the bottom of the unit screen. It partly addresses #370. Other #370 related changes will be followed in consequent pull requests. 