### PR TITLE
Fix for #390:  added 'Solution' to whitelist of 'updated_what' values

### DIFF
--- a/imports/api/rest/post-process-db-change-message.js
+++ b/imports/api/rest/post-process-db-change-message.js
@@ -20,6 +20,7 @@ const updatedWhatWhiteList = [
   'Next Step',
   'AssignedTo',
   'Resolution',
+  'Solution',
   'Status',
   'CC'
 ]


### PR DESCRIPTION
This fixes #390 (The mention in the title didn't create the appropriate reference)
Merge once reviewed