### PR TITLE
Use our own image until upstream is fixed, ref https://github.com/CyC…

### DIFF
--- a/AWS-docker-compose.yml
+++ b/AWS-docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
     meteor:
-      image: ulexus/meteor
+      image: 812644853088.dkr.ecr.ap-southeast-1.amazonaws.com/meteor:latest
       ports:
        - "8080:3000"
       environment:


### PR DESCRIPTION
…oreSystems/docker-meteor/issues/59

Or should I just push to upstream in cases like this?