### PR TITLE
wip: editUnitField

### DIFF
--- a/imports/api/units.js
+++ b/imports/api/units.js
@@ -324,46 +324,16 @@ Meteor.methods({
     }
   },
   [`${collectionName}.editUnitField`] (unitId, changeSet) {
-    check(unitId, Number)
-    const editableFields = [
-      'description',
-      'address'
-    ]
-    Object.keys(changeSet).forEach(fieldName => {
-      if (!editableFields.includes(fieldName)) {
-        throw new Meteor.Error(`illegal field name ${fieldName}`)
-      }
-      const valType = typeof changeSet[fieldName]
-      if (!['number', 'string', 'boolean'].includes(valType)) {
-        throw new Meteor.Error(`illegal value type of ${valType} set to field ${fieldName}`)
-      }
-    })
+    
     if (!Meteor.userId()) {
       throw new Meteor.Error('not-authorized')
     }
 
-    if (Meteor.isClient) {
-      Units.update({id: unitId}, {
+    if (Meteor.isServer) {
+      UnitMetaData.update({bzId: unitId}, {
         $set: changeSet
       })
-    } else { // is server
-      try {
-        // Hi, Naor. the error was that user does not have permission to edit component
-        // I chose /rest/product by referring to .byIdWithUsers in unit.jsx CreateContainer  
-        const { bugzillaCreds: { apiKey } } = Meteor.users.findOne(this.userId)
-        const hello = callAPI('put', `/rest/product/${unitId}`, Object.assign({api_key: apiKey}, changeSet), false, true)
-        console.log('call API returns what?', hello)
-      } catch (e) {
-        console.error({
-          user: Meteor.userId(),
-          method: `${collectionName}.editUnitField`,
-          args: [unitId, changeSet],
-          error: e
-        })
-        throw new Meteor.Error('API error')
-      }
     }
-    // factory.handleChanged(unitId, updatedSet)
   }
 })
 

--- a/imports/api/units.js
+++ b/imports/api/units.js
@@ -322,6 +322,48 @@ Meteor.methods({
 
       return {newUnitId: unitBzId}
     }
+  },
+  [`${collectionName}.editUnitField`] (unitId, changeSet) {
+    check(unitId, Number)
+    const editableFields = [
+      'description',
+      'address'
+    ]
+    Object.keys(changeSet).forEach(fieldName => {
+      if (!editableFields.includes(fieldName)) {
+        throw new Meteor.Error(`illegal field name ${fieldName}`)
+      }
+      const valType = typeof changeSet[fieldName]
+      if (!['number', 'string', 'boolean'].includes(valType)) {
+        throw new Meteor.Error(`illegal value type of ${valType} set to field ${fieldName}`)
+      }
+    })
+    if (!Meteor.userId()) {
+      throw new Meteor.Error('not-authorized')
+    }
+
+    if (Meteor.isClient) {
+      Units.update({id: unitId}, {
+        $set: changeSet
+      })
+    } else { // is server
+      try {
+        // Hi, Naor. the error was that user does not have permission to edit component
+        // I chose /rest/product by referring to .byIdWithUsers in unit.jsx CreateContainer  
+        const { bugzillaCreds: { apiKey } } = Meteor.users.findOne(this.userId)
+        const hello = callAPI('put', `/rest/product/${unitId}`, Object.assign({api_key: apiKey}, changeSet), false, true)
+        console.log('call API returns what?', hello)
+      } catch (e) {
+        console.error({
+          user: Meteor.userId(),
+          method: `${collectionName}.editUnitField`,
+          args: [unitId, changeSet],
+          error: e
+        })
+        throw new Meteor.Error('API error')
+      }
+    }
+    // factory.handleChanged(unitId, updatedSet)
   }
 })
 

--- a/imports/state/epics/edit-unit-field.js
+++ b/imports/state/epics/edit-unit-field.js
@@ -1,0 +1,17 @@
+import { Meteor } from 'meteor/meteor'
+import { filter, debounceTime, distinctUntilChanged, tap, ignoreElements } from 'rxjs/operators'
+
+import { EDIT_UNIT_FIELD } from '../../ui/unit/unit.actions'
+import { collectionName } from '../../api/units'
+
+export const editUnitField = action$ => action$
+  .ofType(EDIT_UNIT_FIELD)
+  .pipe(
+    filter(() => !!Meteor.userId()),
+    debounceTime(750),
+    distinctUntilChanged(),
+    tap(
+      ({changeSet, unitId}) => Meteor.call(`${collectionName}.editUnitField`, parseInt(unitId), changeSet)
+    ),
+    ignoreElements()
+  )

--- a/imports/state/root-epic.js
+++ b/imports/state/root-epic.js
@@ -11,6 +11,7 @@ import { fetchInvitationCredentials } from './epics/fetch-invitation-credentials
 import { updateUserName } from './epics/update-invited-user-name'
 import { logoutUser } from './epics/logout-user'
 import { editCaseField } from './epics/edit-case-field'
+import { editUnitField } from './epics/edit-unit-field'
 import { forgotPass } from './epics/forgot-pass'
 import { checkPassReset } from './epics/check-pass-reset'
 import { resetPass } from './epics/reset-pass'
@@ -32,6 +33,7 @@ export const rootEpic = combineEpics(
   updateUserName,
   logoutUser,
   editCaseField,
+  editUnitField,
   forgotPass,
   checkPassReset,
   resetPass,

--- a/imports/ui/components/editable-autocomplete.jsx
+++ b/imports/ui/components/editable-autocomplete.jsx
@@ -1,0 +1,53 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import AutoComplete from 'material-ui/AutoComplete'
+
+export default class EditableAutocomplete extends Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      value: props.initialValue || '',
+      searchText: props.searchText,
+      countryValid: props.countryValid
+    }
+    this.lastEditTime = 0
+  }
+  componentWillReceiveProps (nextProps) {
+    if (nextProps.initialValue !== this.props.initialValue && Date.now() - this.lastEditTime > 2000) {
+      this.setState({value: nextProps.initialValue})
+    }
+  }
+  handleEdit = (value) => {
+    this.setState({value})
+    this.lastEditTime = Date.now()
+    this.props.onEdit(value)
+  }
+  render () {
+    const { label, dataList, handleNewRequest, handleUpdateInput } = this.props
+    // const { value } = this.state
+
+    return (
+      <AutoComplete
+        floatingLabelText={label}
+        fullWidth
+        anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
+        targetOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        filter={AutoComplete.caseInsensitiveFilter}
+        maxSearchResults={4}
+        onNewRequest={handleNewRequest()}
+        dataSource={dataList}
+        onUpdateInput={handleUpdateInput()}
+        searchText={this.state.searchText}
+        errorText={this.state.countryValid}
+        onChange={({ target: { value } }) => this.handleEdit(value)}
+      />
+    )
+  }
+}
+EditableAutocomplete.propTypes = {
+  label: PropTypes.string.isRequired,
+  onEdit: PropTypes.func.isRequired
+  // isMultiLine: PropTypes.bool,
+  // initialValue: PropTypes.string,
+  // selectionList: PropTypes.array
+}

--- a/imports/ui/unit/unit.actions.js
+++ b/imports/ui/unit/unit.actions.js
@@ -1,0 +1,12 @@
+/// create action edit_unit_field
+/// indicates that in server side that things are being edited 
+/// send this function as a prop in editable item
+export const EDIT_UNIT_FIELD = 'edit_unit_field'
+
+export function editUnitField (changeSet, unitId) {
+  return {
+    type: EDIT_UNIT_FIELD,
+    changeSet,
+    unitId
+  }
+}

--- a/imports/ui/unit/unit.jsx
+++ b/imports/ui/unit/unit.jsx
@@ -25,8 +25,6 @@ import { storeBreadcrumb } from '../general-actions'
 import EditableItem from '../components/editable-item'
 // import EditableAutocomplete from '../components/editable-autocomplete'
 import { editUnitField } from './unit.actions'
-import AutoComplete from 'material-ui/AutoComplete'
-// import countries from 'iso-3166-1-codes'
 
 const viewsOrder = ['cases', 'reports', 'overview']
 
@@ -283,8 +281,8 @@ class Unit extends Component {
                           handleNewRequest={this.handleNewRequest}
                           handleUpdateInput={this.handleUpdateInput}
                           onEdit={changeSet => dispatch(editUnitField({country: changeSet}, unitId))}
-                          searchText={this.state.searchText}                       
-                          countryValid={this.state.countryValid}                     
+                          searchText={this.state.searchText}
+                          countryValid={this.state.countryValid}
                        /> */}
                       </div>
                       <div className='mt3 flex'>

--- a/imports/ui/unit/unit.jsx
+++ b/imports/ui/unit/unit.jsx
@@ -23,7 +23,10 @@ import { infoItemMembers } from '../util/static-info-rendering'
 import { userInfoItem } from '../../util/user'
 import { storeBreadcrumb } from '../general-actions'
 import EditableItem from '../components/editable-item'
+// import EditableAutocomplete from '../components/editable-autocomplete'
 import { editUnitField } from './unit.actions'
+import AutoComplete from 'material-ui/AutoComplete'
+// import countries from 'iso-3166-1-codes'
 
 const viewsOrder = ['cases', 'reports', 'overview']
 
@@ -219,19 +222,29 @@ class Unit extends Component {
                   <div className='flex-grow bg-very-light-gray'>
                     <div className='bg-white card-shadow-1 pa3'>
                       <div>
-                        {infoItemMembers('Unit name', unitName)}
+                        <EditableItem
+                          label='Unit name'
+                          initialValue={unitName}
+                          onEdit={changeSet => dispatch(editUnitField({displayName: changeSet}, unitId))}
+                          isMultiLine
+                        />
                       </div>
                       <div className='mt3'>
                         {infoItemMembers('Unit group', unitItem.classification)}
                       </div>
                       <div className='mt3'>
-                        {infoItemMembers('Unit type', unitItem.metaData.unitType)}
+                        <EditableItem
+                          label='Unit type'
+                          initialValue={unitItem.metaData.unitType}
+                          onEdit={changeSet => dispatch(editUnitField({unitType: changeSet}, unitId))}
+                          isMultiLine
+                        />
                       </div>
                       <div className='mt3'>
                         <EditableItem
                           label='Additional description'
                           initialValue={unitItem.metaData.moreInfo || unitItem.description}
-                          onEdit={changeSet => dispatch(editUnitField({description: changeSet}, unitId))}
+                          onEdit={changeSet => dispatch(editUnitField({moreInfo: changeSet}, unitId))}
                           isMultiLine
                         />
                       </div>
@@ -241,20 +254,55 @@ class Unit extends Component {
                         ADDRESS
                       </div>
                       <div className='mt1'>
-                        {infoItemMembers('Address', unitItem.metaData.streetAddress)}
+                        <EditableItem
+                          label='Address'
+                          initialValue={unitItem.metaData.streetAddress}
+                          onEdit={changeSet => dispatch(editUnitField({streetAddress: changeSet}, unitId))}
+                          isMultiLine
+                        />
                       </div>
                       <div className='mt3'>
-                        {infoItemMembers('City', unitItem.metaData.city)}
+                        <EditableItem
+                          label='City'
+                          initialValue={unitItem.metaData.city}
+                          onEdit={changeSet => dispatch(editUnitField({city: changeSet}, unitId))}
+                          isMultiLine
+                        />
                       </div>
                       <div className='mt3'>
-                        {infoItemMembers('Country', unitItem.metaData.country)}
+                        <EditableItem
+                          label='Country'
+                          initialValue={unitItem.metaData.country}
+                          onEdit={changeSet => dispatch(editUnitField({country: changeSet}, unitId))}
+                          isMultiLine
+                        />
+                        {/* <EditableAutocomplete
+                          label='Country'
+                          dataList={countryList}
+                          initialValue={unitItem.metaData.country}
+                          handleNewRequest={this.handleNewRequest}
+                          handleUpdateInput={this.handleUpdateInput}
+                          onEdit={changeSet => dispatch(editUnitField({country: changeSet}, unitId))}
+                          searchText={this.state.searchText}                       
+                          countryValid={this.state.countryValid}                     
+                       /> */}
                       </div>
                       <div className='mt3 flex'>
                         <div className='flex-grow'>
-                          {infoItemMembers('State', unitItem.metaData.state)}
+                          <EditableItem
+                            label='State'
+                            initialValue={unitItem.metaData.state}
+                            onEdit={changeSet => dispatch(editUnitField({state: changeSet}, unitId))}
+                            isMultiLine
+                          />
                         </div>
                         <div className='flex-grow'>
-                          {infoItemMembers('Zip / Postal code', unitItem.metaData.zipCode)}
+                          <EditableItem
+                            label='Zip / Postal code'
+                            initialValue={unitItem.metaData.zipCode}
+                            onEdit={changeSet => dispatch(editUnitField({zipCode: changeSet}, unitId))}
+                            isMultiLine
+                          />
                         </div>
                       </div>
                     </div>

--- a/imports/ui/unit/unit.jsx
+++ b/imports/ui/unit/unit.jsx
@@ -22,6 +22,8 @@ import Preloader from '../preloader/preloader'
 import { infoItemMembers } from '../util/static-info-rendering'
 import { userInfoItem } from '../../util/user'
 import { storeBreadcrumb } from '../general-actions'
+import EditableItem from '../components/editable-item'
+import { editUnitField } from './unit.actions'
 
 const viewsOrder = ['cases', 'reports', 'overview']
 
@@ -226,7 +228,12 @@ class Unit extends Component {
                         {infoItemMembers('Unit type', unitItem.metaData.unitType)}
                       </div>
                       <div className='mt3'>
-                        {infoItemMembers('Additional description', unitItem.metaData.moreInfo || unitItem.description)}
+                        <EditableItem
+                          label='Additional description'
+                          initialValue={unitItem.metaData.moreInfo || unitItem.description}
+                          onEdit={changeSet => dispatch(editUnitField({description: changeSet}, unitId))}
+                          isMultiLine
+                        />
                       </div>
                     </div>
                     <div className='mt2 bg-white card-shadow-1 pa3'>


### PR DESCRIPTION
@nbiton Afternoon! I have a question regarding to editable fields in Unit/Overview #352. Upon editing, Bugzilla raises an error that user does not have the special permission to edit. 
![image](https://user-images.githubusercontent.com/25441733/43439350-6a3eba8a-94c5-11e8-8d1d-fb999a29e903.png)

To write editUnitField code, I referred to editCaseField. First, I created edit unit field action and action creator in unit.actions.js. Second, I included this action in root-epic.js which I see as a reducer equivalent and which is a part of createStore in store.js. Editable item in unit overview can dispatch the action. Third, I wrote under Meteor method [`${collectionName}.editUnitField`]. I am stuck at this stage of writing meteor server code. When calling API, I chose `/rest/product` because unit-overview referred to .byIdWithUsers in CreateContainer.

Is this a right approach? if yes, how can I grant a user a permission to edit? if no, could you kindly point me to a right diretion? Thank you so much!!   
