### PR TITLE
fix: no overlap between add unit & add case btns (more scrollable space)

### DIFF
--- a/imports/ui/case-explorer/case-explorer.jsx
+++ b/imports/ui/case-explorer/case-explorer.jsx
@@ -134,7 +134,7 @@ class CaseExplorer extends Component {
     return (
       <div className='flex flex-column roboto overflow-hidden flex-grow h-100 relative'>
         <UnverifiedWarning />
-        <div className='bb b--black-10 overflow-auto flex-grow flex flex-column bg-very-light-gray'>
+        <div className='bb b--black-10 overflow-auto flex-grow flex flex-column bg-very-light-gray pb6'>
           <FilterRow
             filterStatus={filterStatus}
             myInvolvement={myInvolvement}

--- a/imports/ui/report-explorer/report-explorer.jsx
+++ b/imports/ui/report-explorer/report-explorer.jsx
@@ -77,7 +77,7 @@ class ReportExplorer extends Component {
       <div className='flex flex-column flex-grow full-height'>
         <RootAppBar title='My Reports' onIconClick={() => dispatch(setDrawerState(true))} shadowless />
         <div className='flex flex-column roboto overflow-hidden flex-grow h-100 relative'>
-          <div className='bb b--black-10 overflow-auto flex-grow flex flex-column bg-very-light-gray'>
+          <div className='bb b--black-10 overflow-auto flex-grow flex flex-column bg-very-light-gray pb6'>
             <FilterRow
               filterStatus={filterStatus}
               myInvolvement={myInvolvement}

--- a/imports/ui/unit-explorer/unit-explorer.jsx
+++ b/imports/ui/unit-explorer/unit-explorer.jsx
@@ -67,7 +67,7 @@ class UnitExplorer extends Component {
               onChangeIndex={this.handleChange}
             >
               {/* tab 1 */}
-              <div className='flex-grow bb b--very-light-gray bg-white'>
+              <div className='flex-grow bb b--very-light-gray bg-white pb6'>
                 <FilteredUnitsList
                   filteredUnits={activeUnits}
                   currentUserId={currentUserId}
@@ -78,7 +78,7 @@ class UnitExplorer extends Component {
                 />
               </div>
               {/* tab 2 */}
-              <div className='flex-grow bb b--very-light-gray bg-white'>
+              <div className='flex-grow bb b--very-light-gray bg-white pb6'>
                 <FilteredUnitsList
                   filteredUnits={disabledUnits}
                   currentUserId={currentUserId}


### PR DESCRIPTION
This fixes #386 (Thank you, Naor 😄😄)
pb6 was used, because pb5 still covers the half of `add case` button.  

**pb6**
<img width="324" align="left" alt="screen shot 2018-08-27 at 6 18 54 pm" src="https://user-images.githubusercontent.com/25441733/44655051-62ed5400-aa26-11e8-9c85-13f9015e7079.png">

**pb5**
<img width="324" align="center" alt="screen shot 2018-08-27 at 6 19 10 pm" src="https://user-images.githubusercontent.com/25441733/44655016-42bd9500-aa26-11e8-9e7b-ea968497f5cb.png">
  