### PR TITLE
Report preview

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,6 +2,7 @@ BUGZILLA_ADMIN_KEY=<generate and copy from BZ>
 INVITE_LAMBDA_URL=<run the "invite" project on a separate port and place the url here>
 APIENROLL_LAMBDA_URL=<run the "apienroll" project on a separate port and place the url here>
 UNIT_CREATE_LAMBDA_URL=<run the "unit" project on a separate port and place the url here, add '/create' at the end>
+PDFGEN_LAMBDA_URL=<point to a real lambda URL running this, for instance https://pdfgen.dev.unee-t.com>
 MAIL_URL=<SMPT provider URL>
 CLOUDINARY_URL=<retrieve by registering for a free account on Cloudinary (should end with /image/upload)>
 CLOUDINARY_PRESET=<generate in your Cloudinary account (look into 'Unsigned Uploading')>

--- a/AWS-docker-compose.yml
+++ b/AWS-docker-compose.yml
@@ -19,6 +19,7 @@ services:
        - INVITE_LAMBDA_URL=${INVITE_LAMBDA_URL}
        - APIENROLL_LAMBDA_URL=${APIENROLL_LAMBDA_URL}
        - UNIT_CREATE_LAMBDA_URL=${UNIT_CREATE_LAMBDA_URL}
+       - PDFGEN_LAMBDA_URL=${PDFGEN_LAMBDA_URL}
       logging:
             driver: awslogs
             options:

--- a/app.json
+++ b/app.json
@@ -42,6 +42,9 @@
     },
     "UNIT_CREATE_LAMBDA_URL": {
       "required": true
+    },
+    "PDFGEN_LAMBDA_URL": {
+      "required": true
     }
   },
   "formation": {

--- a/aws-env.demo
+++ b/aws-env.demo
@@ -4,6 +4,7 @@ export BUGZILLA_URL=https://demo.dashboard.unee-t.com
 export INVITE_LAMBDA_URL=https://invite.demo.unee-t.com
 export UNIT_CREATE_LAMBDA_URL=https://unit.demo.unee-t.com/create
 export APIENROLL_LAMBDA_URL=https://apienroll.demo.unee-t.com
+export PDFGEN_LAMBDA_URL=https://pdfgen.demo.unee-t.com
 export MONGO_PASSWORD=$(aws --profile uneet-demo ssm get-parameters --names MONGO_PASSWORD --with-decryption --query Parameters[0].Value --output text)
 export MONGO_CONNECT=$(aws --profile uneet-demo ssm get-parameters --names MONGO_CONNECT --query Parameters[0].Value --output text)
 # couldinary.demo@unee-t.com

--- a/aws-env.dev
+++ b/aws-env.dev
@@ -4,6 +4,7 @@ export BUGZILLA_URL=https://dev.dashboard.unee-t.com
 export INVITE_LAMBDA_URL=https://invite.dev.unee-t.com
 export UNIT_CREATE_LAMBDA_URL=https://unit.dev.unee-t.com/create
 export APIENROLL_LAMBDA_URL=https://apienroll.dev.unee-t.com
+export PDFGEN_LAMBDA_URL=https://pdfgen.dev.unee-t.com
 export MONGO_PASSWORD=$(aws --profile uneet-dev ssm get-parameters --names MONGO_PASSWORD --with-decryption --query Parameters[0].Value --output text)
 export MONGO_CONNECT=$(aws --profile uneet-dev ssm get-parameters --names MONGO_CONNECT --query Parameters[0].Value --output text)
 export CLOUDINARY_PRESET=$(aws --profile uneet-dev ssm get-parameters --names CLOUDINARY_PRESET --with-decryption --query Parameters[0].Value --output text)

--- a/aws-env.prod
+++ b/aws-env.prod
@@ -4,6 +4,7 @@ export BUGZILLA_URL=https://dashboard.unee-t.com
 export INVITE_LAMBDA_URL=https://invite.unee-t.com
 export UNIT_CREATE_LAMBDA_URL=https://unit.unee-t.com/create
 export APIENROLL_LAMBDA_URL=https://apienroll.unee-t.com
+export PDFGEN_LAMBDA_URL=https://pdfgen.unee-t.com
 export MONGO_PASSWORD=$(aws --profile uneet-prod ssm get-parameters --names MONGO_PASSWORD --with-decryption --query Parameters[0].Value --output text)
 export MONGO_CONNECT=$(aws --profile uneet-prod ssm get-parameters --names MONGO_CONNECT --query Parameters[0].Value --output text)
 export CLOUDINARY_PRESET=$(aws --profile uneet-prod ssm get-parameters --names CLOUDINARY_PRESET --with-decryption --query Parameters[0].Value --output text)

--- a/imports/api/reports.js
+++ b/imports/api/reports.js
@@ -299,7 +299,7 @@ Meteor.methods({
       } catch (e) {
         console.error({
           ...errorLogParams,
-          step: 'Fetch main report object (get /rest/bug/:reportId)',
+          step: `Fetch main report object (get /rest/bug/${reportId})`,
           error: e
         })
         throw new Meteor.Error('API error')

--- a/imports/api/reports.js
+++ b/imports/api/reports.js
@@ -40,7 +40,7 @@ const populateReportDependees = (reportItem, apiKey, logData) => {
     try {
       const comments = bugzillaApi
         .callAPI('get', `/rest/bug/${treeNode.id}/comment`, {api_key: apiKey}, false, true)
-        .data.bugs[reportItem.id.toString()].comments
+        .data.bugs[treeNode.id.toString()].comments
       imageAttachments = comments.reduce((all, comment) => {
         if (attachmentTextMatcher(comment.text)) {
           all.push(comment.text.split('\n')[1])
@@ -321,7 +321,7 @@ Meteor.methods({
       const storedSnapshot = ReportSnapshots.findOne({'reportItem.id': reportId})
       let reportBlob
       if (reportItem.status === REPORT_DRAFT_STATUS || !storedSnapshot) {
-        populateReportDependees(reportItem, apiKey)
+        populateReportDependees(reportItem, apiKey, errorLogParams)
         reportBlob = reportItem
         if (reportItem.status !== REPORT_DRAFT_STATUS) {
           console.log(`No stored snapshot was found for finalized report ${reportId} while creating preview. Creating one as fallback`)

--- a/imports/state/epics/finalize-report.js
+++ b/imports/state/epics/finalize-report.js
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor'
 import { Subject } from 'rxjs/Subject'
-import { go } from 'react-router-redux'
+import { push } from 'react-router-redux'
 import { of } from 'rxjs/observable/of'
 import { merge } from 'rxjs/observable/merge'
 import { collectionName } from '../../api/reports'
@@ -24,7 +24,7 @@ export const finalizeReport = action$ =>
         meteorResult$.complete()
       })
       return merge(
-        of(go(-2)),
+        of(push(`/report/${reportId}/preview`)),
         meteorResult$
       )
     })

--- a/imports/state/epics/generate-report-html-preview.js
+++ b/imports/state/epics/generate-report-html-preview.js
@@ -1,0 +1,33 @@
+import { Meteor } from 'meteor/meteor'
+import { Subject } from 'rxjs/Subject'
+import { merge } from 'rxjs/observable/merge'
+import { of } from 'rxjs/observable/of'
+import {
+  GENERATE_HTML_PREVIEW,
+  HTMLPreviewInProgress,
+  HTMLPreviewReady
+} from '../../ui/report-preview/report-preview.actions'
+import { genericErrorOccurred } from '../../ui/general-actions'
+
+import { collectionName } from '../../api/reports'
+
+export const generateReportHTMLPreview = action$ => action$
+  .ofType(GENERATE_HTML_PREVIEW)
+  .switchMap(({ reportId }) => {
+    const meteorResult$ = new Subject()
+    Meteor.call(`${collectionName}.makePreview`, parseInt(reportId), (err, response) => {
+      if (err) {
+        meteorResult$.next(
+          genericErrorOccurred(`Failed to generate report preview due to: ${err.error}`)
+        )
+        meteorResult$.next(HTMLPreviewReady(reportId, ''))
+      } else {
+        meteorResult$.next(HTMLPreviewReady(reportId, response.url))
+      }
+      meteorResult$.complete()
+    })
+    return merge(
+      meteorResult$,
+      of(HTMLPreviewInProgress(reportId))
+    )
+  })

--- a/imports/state/reducers/report-preview-urls.js
+++ b/imports/state/reducers/report-preview-urls.js
@@ -1,0 +1,25 @@
+import {
+  HTML_PREVIEW_IN_PROGRESS,
+  HTML_PREVIEW_READY
+} from '../../ui/report-preview/report-preview.actions'
+
+export default function reportPreviewUrls (state = {}, action) {
+  switch (action.type) {
+    case HTML_PREVIEW_IN_PROGRESS:
+      return {
+        ...state,
+        [action.reportId.toString()]: {
+          inProgress: true
+        }
+      }
+    case HTML_PREVIEW_READY:
+      return {
+        ...state,
+        [action.reportId.toString()]: {
+          url: action.url
+        }
+      }
+    default:
+      return state
+  }
+}

--- a/imports/state/root-epic.js
+++ b/imports/state/root-epic.js
@@ -22,6 +22,7 @@ import { finalizeReport } from './epics/finalize-report'
 import { editReportField } from './epics/edit-report-field'
 import { addReportAttachment } from './epics/add-report-attachment'
 import { retryReportAttachment } from './epics/retry-report-attachment'
+import { generateReportHTMLPreview } from './epics/generate-report-html-preview'
 
 export const rootEpic = combineEpics(
   createAttachment,
@@ -46,5 +47,6 @@ export const rootEpic = combineEpics(
   finalizeReport,
   editReportField,
   addReportAttachment,
-  retryReportAttachment
+  retryReportAttachment,
+  generateReportHTMLPreview
 )

--- a/imports/state/root-reducer.js
+++ b/imports/state/root-reducer.js
@@ -14,6 +14,7 @@ import drawerState from './reducers/drawer-state'
 import pathBreadcrumb from './reducers/path-breadcrumb'
 import unitCreationState from './reducers/unit-creation-state'
 import genericErrorState from './reducers/generic-error-state'
+import reportPreviewUrls from './reducers/report-preview-urls'
 
 const rootReducer = combineReducers({
   showLoginError,
@@ -30,6 +31,7 @@ const rootReducer = combineReducers({
   unitCreationState,
   reportCreationState,
   genericErrorState,
+  reportPreviewUrls,
   router
 })
 

--- a/imports/ui/app.jsx
+++ b/imports/ui/app.jsx
@@ -19,6 +19,7 @@ import ReportExplorer from './report-explorer/report-explorer'
 import NotificationSettings from './notification-settings/notification-settings'
 import Unit from './unit/unit'
 import ReportWizard from './report-wizard/report-wizard'
+import ReportPreview from './report-preview/report-preview'
 import SideMenu from './side-menu/side-menu'
 import ErrorDialog from './dialogs/error-dialog'
 import ResetLinkSuccessDialog from './dialogs/reset-link-success-dialog'
@@ -44,6 +45,7 @@ class App extends Component {
               <Route exact path='/dashboard' component={Dashboard} />
               <Route exact path='/invitation' component={InvitationLogin} />
               <Route exact path='/notification-settings' component={NotificationSettings} />
+              <Route exact path='/report/:reportId/preview' component={ReportPreview} />
 `             <Route path='/report/:reportId/:viewMode' component={ReportWizard} />
 `             <Route path='/report' component={ReportExplorer} />
               <Route exact path='/case/new' component={CaseWizard} />

--- a/imports/ui/app.jsx
+++ b/imports/ui/app.jsx
@@ -51,7 +51,7 @@ class App extends Component {
               <Route exact path='/invitation' component={InvitationLogin} />
               <Route exact path='/notification-settings' component={NotificationSettings} />
               <Route exact path='/report/:reportId/preview' component={ReportPreview} />
-`             <Routepath='/report/:reportId/:viewMode' component={ReportWizard} />
+`             <Route path='/report/:reportId/:viewMode' component={ReportWizard} />
 `             <Route path='/report' component={ReportExplorer} />
               <Route exact path='/case/new' component={CaseWizard} />
               <Route path='/case' component={CaseMaster} />

--- a/imports/ui/report-preview/report-preview.actions.js
+++ b/imports/ui/report-preview/report-preview.actions.js
@@ -1,0 +1,25 @@
+export const GENERATE_HTML_PREVIEW = 'generate_report_export_html_preview'
+export const HTML_PREVIEW_IN_PROGRESS = 'generate_report_export_html_preview_in_progress'
+export const HTML_PREVIEW_READY = 'report_export_html_preview_is_ready'
+
+export function generateHTMLPreview (reportId) {
+  return {
+    type: GENERATE_HTML_PREVIEW,
+    reportId
+  }
+}
+
+export function HTMLPreviewInProgress (reportId) {
+  return {
+    type: HTML_PREVIEW_IN_PROGRESS,
+    reportId
+  }
+}
+
+export function HTMLPreviewReady (reportId, url) {
+  return {
+    type: HTML_PREVIEW_READY,
+    reportId,
+    url
+  }
+}

--- a/imports/ui/report-preview/report-preview.jsx
+++ b/imports/ui/report-preview/report-preview.jsx
@@ -1,0 +1,67 @@
+import React, { Component } from 'react'
+import { Meteor } from 'meteor/meteor'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { createContainer } from 'meteor/react-meteor-data'
+import { goBack } from 'react-router-redux'
+import CircularProgress from 'material-ui/CircularProgress'
+
+import Reports, { collectionName/*, REPORT_FINAL_STATUS */ } from '../../api/reports'
+import InnerAppBar from '../components/inner-app-bar'
+import Preloader from '../preloader/preloader'
+import { generateHTMLPreview } from './report-preview.actions'
+
+class ReportPreview extends Component {
+  componentDidMount () {
+    const { match, dispatch } = this.props
+    dispatch(generateHTMLPreview(match.params.reportId))
+  }
+  render () {
+    const { isLoading, reportItem, dispatch, previewIsLoading, previewUrl } = this.props
+    if (isLoading) {
+      return <Preloader />
+    }
+
+    return (
+      <div className='full-height flex flex-column'>
+        <InnerAppBar onBack={() => dispatch(goBack())} title={reportItem.title} />
+        <div className='flex-grow overflow-auto flex flex-column'>
+          {previewIsLoading ? (
+            <div className='flex-grow flex items-center justify-center'>
+              <CircularProgress size={70} thickness={5} />
+            </div>
+          ) : previewUrl && (
+            <iframe className='bn flex-grow' src={previewUrl} />
+          )}
+        </div>
+      </div>
+    )
+  }
+}
+
+ReportPreview.propTypes = {
+  isLoading: PropTypes.bool.isRequired,
+  previewIsLoading: PropTypes.bool.isRequired,
+  reportItem: PropTypes.object,
+  previewUrl: PropTypes.string
+}
+
+export default connect(
+  ({ reportPreviewUrls }, props) => {
+    const { reportId } = props.match.params
+    const previewInfo = reportPreviewUrls[reportId.toString()]
+    return {
+      previewIsLoading: !!previewInfo && !!previewInfo.inProgress,
+      previewUrl: previewInfo && previewInfo.url
+    }
+  }
+)(
+  createContainer(props => {
+    const { reportId } = props.match.params
+    const reportHandle = Meteor.subscribe(`${collectionName}.byId`, reportId)
+    return {
+      isLoading: !reportHandle.ready(),
+      reportItem: Reports.findOne({id: parseInt(reportId)})
+    }
+  }, ReportPreview)
+)

--- a/imports/ui/report-preview/report-preview.jsx
+++ b/imports/ui/report-preview/report-preview.jsx
@@ -3,10 +3,12 @@ import { Meteor } from 'meteor/meteor'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { createContainer } from 'meteor/react-meteor-data'
-import { goBack } from 'react-router-redux'
+import { goBack, push } from 'react-router-redux'
 import CircularProgress from 'material-ui/CircularProgress'
+import FontIcon from 'material-ui/FontIcon'
+import RaisedButton from 'material-ui/RaisedButton'
 
-import Reports, { collectionName/*, REPORT_FINAL_STATUS */ } from '../../api/reports'
+import Reports, { collectionName, REPORT_FINAL_STATUS } from '../../api/reports'
 import InnerAppBar from '../components/inner-app-bar'
 import Preloader from '../preloader/preloader'
 import { generateHTMLPreview } from './report-preview.actions'
@@ -22,6 +24,7 @@ class ReportPreview extends Component {
       return <Preloader />
     }
 
+    const isFinal = reportItem.status === REPORT_FINAL_STATUS
     return (
       <div className='full-height flex flex-column'>
         <InnerAppBar onBack={() => dispatch(goBack())} title={reportItem.title} />
@@ -32,6 +35,36 @@ class ReportPreview extends Component {
             </div>
           ) : previewUrl && (
             <iframe className='bn flex-grow' src={previewUrl} />
+          )}
+          {isFinal && (
+            <div className='bg-white scroll-shadow-1 pa3 tc'>
+              <div className='flex items-center justify-center'>
+                <FontIcon className='material-icons' color='var(--success-green)' style={{fontSize: '2rem'}}>
+                  check_circle
+                </FontIcon>
+                <h3 className='fw5 lh-solid ml1 dark-gray ma0'>Report Complete</h3>
+              </div>
+              <div className='dark-gray lh-title mt2'>
+                Report <span className='fw7'>{reportItem.title}</span> is complete. <br />
+                Would you like to endorse the report?
+              </div>
+              <div className='mt3'>
+                <RaisedButton
+                  primary
+                  disabled
+                  onClick={() => dispatch(push(`/report/${reportItem.id}/endorse`))}
+                >
+                  <span className='white mh4'>
+                    Endorse Report
+                  </span>
+                </RaisedButton>
+              </div>
+              <div className='mt2'>
+                <a className='link bondi-blue fw5' onClick={() => dispatch(goBack())}>
+                  No thanks, I'll do it later
+                </a>
+              </div>
+            </div>
           )}
         </div>
       </div>

--- a/imports/ui/report-wizard/report-wizard.jsx
+++ b/imports/ui/report-wizard/report-wizard.jsx
@@ -204,18 +204,31 @@ class ReportWizard extends Component {
         </div>
         <div className='bg-white ph3 pb3 pt4 tr scroll-shadow-1 z-999'>
           <div className='dib flex justify-end items-center'>
-            {isDraft ? (
-              <RaisedButton
-                className='ml2'
-                key='confirm'
-                primary
-                onClick={() => dispatch(push(`${match.url}/confirm`))}
-              >
-                <span className='white mh4'>
-                  Complete
-                </span>
-              </RaisedButton>
-            ) : [
+            {isDraft ? [
+              (
+                <RaisedButton
+                  className='ml2'
+                  key='preview'
+                  onClick={() => dispatch(push(`/report/${reportItem.id}/preview`))}
+                >
+                  <span className='bondi-blue mh4'>
+                    Preview
+                  </span>
+                </RaisedButton>
+              ),
+              (
+                <RaisedButton
+                  className='ml2'
+                  key='confirm'
+                  primary
+                  onClick={() => dispatch(push(`${match.url}/confirm`))}
+                >
+                  <span className='white mh4'>
+                    Complete
+                  </span>
+                </RaisedButton>
+              )
+            ] : [
               (
                 <div key='text' className='f5 i moon-gray'>
                   This report has been finalized

--- a/imports/ui/report-wizard/report-wizard.jsx
+++ b/imports/ui/report-wizard/report-wizard.jsx
@@ -202,45 +202,48 @@ class ReportWizard extends Component {
             {makeCreationButton('Add room', () => {})}
           </div> */}
         </div>
-        <div className='bg-white ph3 pb3 pt4 tr scroll-shadow-1 z-999'>
-          <div className='dib flex justify-end items-center'>
-            {isDraft ? [
-              (
-                <RaisedButton
-                  className='ml2'
-                  key='preview'
-                  onClick={() => dispatch(push(`/report/${reportItem.id}/preview`))}
-                >
-                  <span className='bondi-blue mh4'>
-                    Preview
-                  </span>
-                </RaisedButton>
-              ),
-              (
-                <RaisedButton
-                  className='ml2'
-                  key='confirm'
-                  primary
-                  onClick={() => dispatch(push(`${match.url}/confirm`))}
-                >
-                  <span className='white mh4'>
-                    Complete
-                  </span>
-                </RaisedButton>
-              )
-            ] : [
-              (
+        <div className='bg-white tr scroll-shadow-1 z-999'>
+          {isDraft ? (
+            <div className='dib ph3 pb3 pt4 flex justify-end items-center'>
+              <RaisedButton
+                onClick={() => dispatch(push(`/report/${reportItem.id}/preview`))}
+              >
+                <span className='bondi-blue mh4'>
+                  Preview
+                </span>
+              </RaisedButton>
+              <RaisedButton
+                className='ml2'
+                primary
+                onClick={() => dispatch(push(`${match.url}/confirm`))}
+              >
+                <span className='white mh4'>
+                  Complete
+                </span>
+              </RaisedButton>
+            </div>
+          ) : (
+            <div className='dib ph3 pb3 pt2'>
+              <div className='flex justify-end items-center'>
                 <div key='text' className='f5 i moon-gray'>
                   This report has been finalized
                 </div>
-              ),
-              (
                 <FontIcon key='icon' className='material-icons ml2' color='var(--success-green)'>
                   check_circle
                 </FontIcon>
-              )
-            ]}
-          </div>
+              </div>
+              <div className='tr mt2'>
+                <RaisedButton
+                  primary
+                  onClick={() => dispatch(push(`/report/${reportItem.id}/preview`))}
+                >
+                  <span className='white mh4'>
+                    Preview & Endorse
+                  </span>
+                </RaisedButton>
+              </div>
+            </div>
+          )}
         </div>
         {isDraft && (
           <Route exact path={`${match.url}/confirm`} children={({ match }) => (

--- a/imports/util/bugzilla-api.js
+++ b/imports/util/bugzilla-api.js
@@ -24,3 +24,7 @@ export function callAPI (method, endpoint, payload = {}, isAdmin = false, isSync
   const httpCall = HTTP.call(method, base + endpoint, options, callback)
   return returnedPromise || httpCall
 }
+
+export default {
+  callAPI
+}


### PR DESCRIPTION
Currently shows the preview in new '/preview' route.
The generated preview is based off live data if the report is not finalized. 
If it is finalized, it's based off the snapshot taken when it was finalized.

From now, image attachments are stored within the snapshot to make sure none were added since the moment of finalization.