### PR TITLE
feat: temporarily hide search icon for case & report pages

### DIFF
--- a/imports/ui/components/root-app-bar.jsx
+++ b/imports/ui/components/root-app-bar.jsx
@@ -63,7 +63,7 @@ class RootAppBar extends Component {
         }
         iconElementRight={
           <div>
-            <span className={(!showSearch || searchTextDisplay ? 'dn' : '')}>
+            <span className={((!showSearch || searchTextDisplay) ? 'dn' : '')}>
               <IconButton onClick={() => this.setState({searchTextDisplay: true})}>
                 <FontIcon className='material-icons' color='white'>
                   search

--- a/imports/ui/components/root-app-bar.jsx
+++ b/imports/ui/components/root-app-bar.jsx
@@ -63,7 +63,7 @@ class RootAppBar extends Component {
         }
         iconElementRight={
           <div>
-            <span className={(searchTextDisplay ? 'dn' : '')}>
+            <span className={(searchTextDisplay || title !== 'My Units' ? 'dn' : '')}>
               <IconButton onClick={() => this.setState({searchTextDisplay: true})}>
                 <FontIcon className='material-icons' color='white'>
                   search

--- a/imports/ui/components/root-app-bar.jsx
+++ b/imports/ui/components/root-app-bar.jsx
@@ -25,7 +25,7 @@ class RootAppBar extends Component {
   }
 
   render () {
-    const { title, onSearchChanged, placeholder, onIconClick, shadowless, searchText } = this.props
+    const { title, onSearchChanged, placeholder, onIconClick, shadowless, searchText, showSearch } = this.props
     const { searchTextDisplay } = this.state
     return (
       <AppBar
@@ -63,7 +63,7 @@ class RootAppBar extends Component {
         }
         iconElementRight={
           <div>
-            <span className={(searchTextDisplay || title !== 'My Units' ? 'dn' : '')}>
+            <span className={(!showSearch || searchTextDisplay ? 'dn' : '')}>
               <IconButton onClick={() => this.setState({searchTextDisplay: true})}>
                 <FontIcon className='material-icons' color='white'>
                   search

--- a/imports/ui/unit-explorer/unit-explorer.jsx
+++ b/imports/ui/unit-explorer/unit-explorer.jsx
@@ -73,6 +73,7 @@ class UnitExplorer extends Component {
           shadowless
           searchText={searchText}
           onSearchChanged={this.onSearchChanged}
+          showSearch
         />
         <UnverifiedWarning />
         { searchMode ? (


### PR DESCRIPTION
temporarily fixes #517 
The search icon is hidden in report & case pages as per Frank's request.

Following is just a note for myself if I were to fix this in future.  
1) I was not sure whether to filter by case name or unit title. Also, desktop version uses rootAppBar, while mobile version uses mobileHeader. 
2) A quick solution for mobile version Appbar was to retrieve data for a filter function in case-master.jsx. It seemed redundant since case-explorer.jsx already does that. 

