### PR TITLE
fix: display only the active units when we search for a unit during case or report creation

### DIFF
--- a/imports/ui/dialogs/unit-select-dialog.jsx
+++ b/imports/ui/dialogs/unit-select-dialog.jsx
@@ -47,7 +47,7 @@ class UnitSelectDialog extends Component {
   render () {
     const { show, onDismissed, inProgress, unitList, onUnitClick, isLoading } = this.props
     const { searchText, searchMode, searchResult } = this.state
-    const units = searchMode ? searchResult : unitList
+    const units = searchMode ? searchResult : unitList.filter(unitItem => unitItem.is_active)
     const actions =
       <div className='tc pa2 bg-bondi-blue'>
         <Link className={'white link ph3 br1 b--none pv2 lh-title dim' + (units.length === 0 ? 'dn' : '')}


### PR DESCRIPTION
fixes #573 
