### PR TITLE
Extended case search to id and unit name in addition to case title

### DIFF
--- a/imports/state/reducers/case-search-state.js
+++ b/imports/state/reducers/case-search-state.js
@@ -2,20 +2,26 @@ import {
   UPDATE_SEARCH_RESULT,
   SEARCH_ERROR,
   FINISH_SEARCH,
-  START_SEARCH
+  START_SEARCH,
+  NAVIGATION_REQUESTED,
+  NAVIGATION_GRANTED
 } from '../../ui/case/case-search.actions'
 
-const initialState = { searchText: '', searchActive: false }
+const initialState = { searchText: '', searchActive: false, navigationRequested: false }
 export default function caseSearchState (state = initialState, action) {
   switch (action.type) {
     case SEARCH_ERROR:
       return action.value.error.message || action.value.message
     case UPDATE_SEARCH_RESULT:
-      return Object.assign({}, state, { searchText: action.searchText })
+      return Object.assign({}, state, { searchText: action.searchText, navigationRequested: false })
     case FINISH_SEARCH:
-      return Object.assign({}, state, { searchActive: false })
+      return Object.assign({}, state, { searchActive: false, navigationRequested: false })
     case START_SEARCH:
-      return Object.assign({}, state, { searchActive: true })
+      return Object.assign({}, state, { searchActive: true, navigationRequested: false })
+    case NAVIGATION_REQUESTED:
+      return Object.assign({}, state, { navigationRequested: true })
+    case NAVIGATION_GRANTED:
+      return Object.assign({}, state, { navigationRequested: false })
   }
   return state
 }

--- a/imports/ui/case-explorer/case-explorer.jsx
+++ b/imports/ui/case-explorer/case-explorer.jsx
@@ -56,7 +56,7 @@ class CaseExplorer extends Component {
     if (!isLoading && !casesError && isLoading !== this.props.isLoading) {
       this.props.dispatchLoadingResult({ caseList })
     }
-    if(navigationRequested && this.primeCaseId) {
+    if (navigationRequested && this.primeCaseId) {
       this.props.dispatch(push(`/case/${this.primeCaseId}`))
     }
   }
@@ -156,35 +156,35 @@ class CaseExplorer extends Component {
       this.primeCaseId = null
       if (!searchText) return cases
 
-      let primeCase, caseResult, results
-      let selectedCfg, searchCfg = {
-        num:{
-          flds: ["_id", "title", "selectedUnit"],
-          redirectOnFieldMatch: "_id", // full match agains id will allow redirect to matched case uppon "Enter"
+      let caseResult, results, selectedCfg
+      let searchCfg = {
+        num: {
+          flds: ['_id', 'title', 'selectedUnit'],
+          redirectOnFieldMatch: '_id', // full match agains id will allow redirect to matched case uppon "Enter"
           // regex: new RegExp(`(^|[^\\d])${searchText}`, 'i'),
-          regex: new RegExp( `${searchText}`, 'i')
+          regex: new RegExp(`${searchText}`, 'i')
         },
-        txt:{
-          flds: ["title", "selectedUnit"],
+        txt: {
+          flds: ['title', 'selectedUnit'],
           // regex: new RegExp(`(^|[^a-zA-Z])${searchText}`, 'i'),
-          regex: new RegExp( `${searchText}`, 'i')
+          regex: new RegExp(`${searchText}`, 'i')
         }
       }
 
       // Checking the first character of the search term to determine if it's a numerical or alphabetical search
-      selectedCfg = searchCfg[ searchText.charAt(0).match(/\d/) ? 'num' : 'txt' ] ;
+      selectedCfg = searchCfg[ searchText.charAt(0).match(/\d/) ? 'num' : 'txt' ]
       results = cases.filter(item => {
-        return selectedCfg.flds.some( fld => {
-          caseResult = item[fld].match( selectedCfg.regex )
-          if( caseResult ) {
-            if( !this.primeCaseId && fld == selectedCfg.redirectOnFieldMatch && caseResult.input == caseResult[0] ) {
+        return selectedCfg.flds.some(fld => {
+          caseResult = item[fld].match(selectedCfg.regex)
+          if (caseResult) {
+            if (!this.primeCaseId && fld === selectedCfg.redirectOnFieldMatch && caseResult.input === caseResult[0]) {
               this.primeCaseId = item.id
             }
           }
           return !!caseResult
-        } )
-      } )
-      return results 
+        })
+      })
+      return results
     },
     (a, b) => {
       if (Array.isArray(a) && Array.isArray(b)) {

--- a/imports/ui/case-explorer/case-explorer.jsx
+++ b/imports/ui/case-explorer/case-explorer.jsx
@@ -22,7 +22,7 @@ import { push } from 'react-router-redux'
 import { SORT_BY, sorters, labels } from '../explorer-components/sort-items'
 import { RoleFilter } from '../explorer-components/role-filter'
 import { Sorter } from '../explorer-components/sorter'
-import { finishSearch, startSearch, updateSearch } from '../case/case-search.actions'
+import { finishSearch, startSearch, updateSearch, navigationRequested, navigationGranted } from '../case/case-search.actions'
 
 class CaseExplorer extends Component {
   constructor () {
@@ -52,11 +52,20 @@ class CaseExplorer extends Component {
     dispatch(push(`/case/new?unit=${unitId}`))
   }
 
-  componentWillReceiveProps ({ isLoading, casesError, caseList }) {
+  componentWillReceiveProps ({ isLoading, casesError, caseList, navigationRequested }) {
     if (!isLoading && !casesError && isLoading !== this.props.isLoading) {
       this.props.dispatchLoadingResult({ caseList })
     }
+    if(navigationRequested && this.primeCaseId) {
+      this.props.dispatch(push(`/case/${this.primeCaseId}`))
+    }
   }
+
+  componentWillUnmount () {
+    this.primeCaseId = null
+    this.props.dispatch(navigationGranted())
+  }
+
   makeCaseUpdateTimeDict = memoizeOne(
     allNotifications => allNotifications.reduce((dict, curr) => {
       const caseIdStr = curr.caseId.toString()
@@ -142,16 +151,38 @@ class CaseExplorer extends Component {
   )
   filterCases = memoizeOne(
     (cases, searchText) => {
+      this.primeCaseId = null
       if (!searchText) return cases
-      let regex
+
+      let primeCase, caseResult, results
+      let selectedCfg, searchCfg = {
+        num:{
+          flds: ["_id", "title", "selectedUnit"],
+          redirectOnFieldMatch: "_id", // full match agains id will allow redirect to matched case uppon "Enter"
+          // regex: new RegExp(`(^|[^\\d])${searchText}`, 'i'),
+          regex: new RegExp( `${searchText}`, 'i')
+        },
+        txt:{
+          flds: ["title", "selectedUnit"],
+          // regex: new RegExp(`(^|[^a-zA-Z])${searchText}`, 'i'),
+          regex: new RegExp( `${searchText}`, 'i')
+        }
+      }
 
       // Checking the first character of the search term to determine if it's a numerical or alphabetical search
-      if (searchText.charAt(0).match(/\d/)) {
-        regex = new RegExp(`(^|[^\\d])${searchText}`, 'i') // Searching for a number starting as the search term
-      } else {
-        regex = new RegExp(`(^|[^a-zA-Z])${searchText}`, 'i') // Searching for a word starting as the search term
-      }
-      return cases.filter(item => item.title.match(regex))
+      selectedCfg = searchCfg[ searchText.charAt(0).match(/\d/) ? 'num' : 'txt' ] ;
+      results = cases.filter(item => {
+        return selectedCfg.flds.some( fld => {
+          caseResult = item[fld].match( selectedCfg.regex )
+          if( caseResult ) {
+            if( !this.primeCaseId && fld == selectedCfg.redirectOnFieldMatch && caseResult.input == caseResult[0] ) {
+              this.primeCaseId = item.id
+            }
+          }
+          return !!caseResult
+        } )
+      } )
+      return results 
     },
     (a, b) => {
       if (Array.isArray(a) && Array.isArray(b)) {
@@ -226,13 +257,18 @@ CaseExplorer.propTypes = {
   casesError: PropTypes.object,
   allNotifications: PropTypes.array.isRequired,
   unreadNotifications: PropTypes.array.isRequired,
-  dispatchLoadingResult: PropTypes.func.isRequired
+  dispatchLoadingResult: PropTypes.func.isRequired,
+  navigationRequested: PropTypes.bool
 }
 
 let casesError
 let unitsError
 const connectedWrapper = connect(
-  ({ caseSearchState }) => ({ searchText: caseSearchState.searchText, searchActive: caseSearchState.searchActive }) // map redux state to props
+  ({ caseSearchState }) => ({
+    searchText: caseSearchState.searchText,
+    searchActive: caseSearchState.searchActive,
+    navigationRequested: caseSearchState.navigationRequested
+  }) // map redux state to props
 )(createContainer(() => { // map meteor state to props
   const casesHandle = Meteor.subscribe(`${collectionName}.associatedWithMe`, { showOpenOnly: true }, {
     onStop: (error) => {
@@ -275,6 +311,7 @@ class CaseExplorerHeader extends Component {
         searchActive={searchActive}
         rightSideElement={rightSideElement}
         showSearch
+        onNavigationRequested={() => dispatch(navigationRequested())}
       />
     )
   }
@@ -288,7 +325,10 @@ CaseExplorerHeader.propsTypes = {
 }
 
 connectedWrapper.MobileHeader = connect(
-  ({ caseSearchState }) => ({ searchText: caseSearchState.searchText, searchActive: caseSearchState.searchActive })
+  ({ caseSearchState }) => ({
+    searchText: caseSearchState.searchText,
+    searchActive: caseSearchState.searchActive
+  })
 )(CaseExplorerHeader)
 
 connectedWrapper.MobileHeader.propTypes = {

--- a/imports/ui/case-explorer/case-explorer.jsx
+++ b/imports/ui/case-explorer/case-explorer.jsx
@@ -156,26 +156,23 @@ class CaseExplorer extends Component {
       this.primeCaseId = null
       if (!searchText) return cases
 
-      let caseResult, results, selectedCfg
-      let searchCfg = {
+      const searchCfg = {
         num: {
           flds: ['_id', 'title', 'selectedUnit'],
           redirectOnFieldMatch: '_id', // full match agains id will allow redirect to matched case uppon "Enter"
-          // regex: new RegExp(`(^|[^\\d])${searchText}`, 'i'),
-          regex: new RegExp(`${searchText}`, 'i')
+          regex: new RegExp(`(^|[^\\d])${searchText}`, 'i')
         },
         txt: {
           flds: ['title', 'selectedUnit'],
-          // regex: new RegExp(`(^|[^a-zA-Z])${searchText}`, 'i'),
-          regex: new RegExp(`${searchText}`, 'i')
+          regex: new RegExp(`(^|[^a-zA-Z])${searchText}`, 'i')
         }
       }
 
       // Checking the first character of the search term to determine if it's a numerical or alphabetical search
-      selectedCfg = searchCfg[ searchText.charAt(0).match(/\d/) ? 'num' : 'txt' ]
-      results = cases.filter(item => {
+      const selectedCfg = searchCfg[ searchText.charAt(0).match(/\d/) ? 'num' : 'txt' ]
+      const results = cases.filter(item => {
         return selectedCfg.flds.some(fld => {
-          caseResult = item[fld].match(selectedCfg.regex)
+          const caseResult = item[fld].match(selectedCfg.regex)
           if (caseResult) {
             if (!this.primeCaseId && fld === selectedCfg.redirectOnFieldMatch && caseResult.input === caseResult[0]) {
               this.primeCaseId = item.id

--- a/imports/ui/case/case-search.actions.js
+++ b/imports/ui/case/case-search.actions.js
@@ -1,11 +1,14 @@
 export const UPDATE_SEARCH_RESULT = 'update_search_result'
 export const FINISH_SEARCH = 'finish_search'
 export const START_SEARCH = 'start_search'
+export const NAVIGATION_REQUESTED = 'navigation_requested'
+export const NAVIGATION_GRANTED = 'navigation_granted'
 
 export function updateSearch (searchText) {
   return {
     type: UPDATE_SEARCH_RESULT,
-    searchText: searchText
+    searchText: searchText,
+    navigationRequested: false
   }
 }
 
@@ -20,5 +23,19 @@ export function startSearch () {
   return {
     type: START_SEARCH,
     searchFinished: false
+  }
+}
+
+export function navigationRequested () {
+  return {
+    type: NAVIGATION_REQUESTED,
+    navigationRequested: true
+  }
+}
+
+export function navigationGranted () {
+  return {
+    type: NAVIGATION_GRANTED,
+    navigationRequested: false
   }
 }

--- a/imports/ui/case/case-search.actions.js
+++ b/imports/ui/case/case-search.actions.js
@@ -7,8 +7,7 @@ export const NAVIGATION_GRANTED = 'navigation_granted'
 export function updateSearch (searchText) {
   return {
     type: UPDATE_SEARCH_RESULT,
-    searchText: searchText,
-    navigationRequested: false
+    searchText: searchText
   }
 }
 
@@ -28,14 +27,12 @@ export function startSearch () {
 
 export function navigationRequested () {
   return {
-    type: NAVIGATION_REQUESTED,
-    navigationRequested: true
+    type: NAVIGATION_REQUESTED
   }
 }
 
 export function navigationGranted () {
   return {
-    type: NAVIGATION_GRANTED,
-    navigationRequested: false
+    type: NAVIGATION_GRANTED
   }
 }

--- a/imports/ui/components/root-app-bar.jsx
+++ b/imports/ui/components/root-app-bar.jsx
@@ -23,6 +23,7 @@ type Props = {
   title: string,
   onIconClick?: (evt: Event) => void,
   onSearchChanged?: (searchText: string) => void,
+  onNavigationRequested?: () => void,
   searchText?: string,
   onSearchRequested?: () => void,
   onBackClicked?: () => void,
@@ -34,7 +35,7 @@ export default class RootAppBar extends React.Component<Props> {
   render () {
     const {
       title, onIconClick, shadowless, searchText, showSearch, rightSideElement,
-      onSearchRequested, onBackClicked, onSearchChanged, searchActive
+      onSearchRequested, onBackClicked, onSearchChanged, searchActive, onNavigationRequested
     } = this.props
     return (
       <AppBar
@@ -49,6 +50,11 @@ export default class RootAppBar extends React.Component<Props> {
               fullWidth
               value={searchText}
               onChange={evt => onSearchChanged && onSearchChanged(evt.target.value)}
+              onKeyPress={evt => {
+                if (evt.charCode === 13) {
+                  onNavigationRequested && onNavigationRequested()
+                }
+              }}
             />
           )
           : (title)


### PR DESCRIPTION
Search by case number does not work #679
- searching in fields: id, title, unit name
- pressing 'ENTER' with matching id will auto redirect to case page