### PR TITLE
Tweak ECS memory as recommend by AWS

### DIFF
--- a/AWS-docker-compose.yml
+++ b/AWS-docker-compose.yml
@@ -2,7 +2,8 @@ version: '2'
 services:
     meteor:
         image: ulexus/meteor:build
-        mem_limit: 1g
+        mem_reservation: 1g
+        mem_limit: 2g
         ports:
             - "8080:3000"
         environment:


### PR DESCRIPTION
Bit of a balancing act with Bugzilla memory consumption, since it's on ECS