### PR TITLE
Cache node_modules to make build faster

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,26 +9,14 @@ phases:
   pre_build:
     commands:
       - $(aws ecr get-login --no-include-email --region ${AWS_REGION})
-  install:
-    commands:
-      - echo Installing Meteor
-      - curl https://install.meteor.com/ | sh
   build:
     commands:
-      - meteor npm install
-      - 'sed -i "s,<\!-- COMMIT: -->,<\!-- COMMIT: $CODEBUILD_SOURCE_VERSION $CODEBUILD_RESOLVED_SOURCE_VERSION -->,g" client/main.html'
-      - meteor build --directory /tmp/export-meteor/build --allow-superuser
-      - printf "FROM ulexus/meteor:build\nCOPY build /home/meteor/www\nRUN chown -R meteor:meteor /home/meteor/\n" >/tmp/export-meteor/Dockerfile
-      - cd /tmp/export-meteor
       - docker build -t ${APP} -t ${APP}:$CODEBUILD_RESOLVED_SOURCE_VERSION .
-      - docker tag ${APP}:$CODEBUILD_RESOLVED_SOURCE_VERSION ${ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/${APP}:$CODEBUILD_RESOLVED_SOURCE_VERSION
-      - docker tag ${APP}:latest ${ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/${APP}:latest
+      - docker tag ${APP}:$CODEBUILD_RESOLVED_SOURCE_VERSION
+        ${ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/${APP}:$CODEBUILD_RESOLVED_SOURCE_VERSION
+      - docker tag ${APP}:latest
+        ${ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/${APP}:latest
   post_build:
     commands:
       - docker push ${ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/${APP}:$CODEBUILD_RESOLVED_SOURCE_VERSION
       - docker push ${ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/${APP}:latest
-
-# https://aws.amazon.com/blogs/devops/improve-build-performance-and-save-time-using-local-caching-in-aws-codebuild/
-cache:
-  paths:
-   - 'node_modules/**/*'

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -27,3 +27,8 @@ phases:
     commands:
       - docker push ${ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/${APP}:$CODEBUILD_RESOLVED_SOURCE_VERSION
       - docker push ${ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/${APP}:latest
+
+# https://aws.amazon.com/blogs/devops/improve-build-performance-and-save-time-using-local-caching-in-aws-codebuild/
+cache:
+  paths:
+   - 'node_modules/**/*'


### PR DESCRIPTION
We are using codebuild alongside Travis atm. Idea is to gradually replace Travis.