### PR TITLE
MEFE internal API- setting user's notification settings for a unit (8th installment)

### DIFF
--- a/imports/api/custom-users.js
+++ b/imports/api/custom-users.js
@@ -35,28 +35,30 @@ const verifyUserLogin = handle => {
   return true
 }
 
-export const baseUserSchema = Object.freeze({
-  notificationSettings: {
-    assignedNewCase: true,
-    assignedExistingCase: true,
-    invitedToCase: true,
-    caseNewMessage: true,
-    caseUpdate: false,
-    caseUpdate_types: {
-      'Next Step': true,
-      'Solution': true,
-      'Deadline': true,
-      'StatusResolved': true
-    },
-    caseNewMessage_types: {
-      'Tenant': true,
-      'Owner/Landlord': true,
-      'Contractor': true,
-      'Management Company': true,
-      'Agent': true
-    },
-    severityOverrideThreshold: null
+export const defaultNotificationSettings = {
+  // assignedNewCase: true,
+  assignedExistingCase: true,
+  invitedToCase: true,
+  caseNewMessage: true,
+  caseUpdate: false,
+  caseUpdate_types: {
+    'Next Step': true,
+    'Solution': true,
+    'Deadline': true,
+    'StatusResolved': true
   },
+  caseNewMessage_types: {
+    'Tenant': true,
+    'Owner/Landlord': true,
+    'Contractor': true,
+    'Management Company': true,
+    'Agent': true
+  },
+  severityOverrideThreshold: null
+}
+
+export const baseUserSchema = Object.freeze({
+  notificationSettings: defaultNotificationSettings,
   customReportLogoEnabled: true
 }) // excludes the default parts like profile, services and emails, and the added "bugzillaCreds" that's set on creation
 
@@ -94,7 +96,7 @@ if (Meteor.isServer) {
 }
 
 const notifSettsNames = [
-  'assignedNewCase',
+  // 'assignedNewCase',
   'assignedExistingCase',
   'invitedToCase',
   'caseNewMessage',

--- a/imports/ui/notification-settings/notification-settings.jsx
+++ b/imports/ui/notification-settings/notification-settings.jsx
@@ -28,13 +28,7 @@ class NotificationSettings extends Component {
             <div className={!settings ? 'o-40' : ''}>
               <Toggle
                 className='mt2' labelStyle={toggleLabelStyle}
-                label='When assigned to a new case'
-                toggled={!!settings && settings.assignedNewCase}
-                onToggle={(evt, isChecked) => this.handleSettingToggled('assignedNewCase', isChecked)}
-              />
-              <Toggle
-                className='mt2' labelStyle={toggleLabelStyle}
-                label='When assigned to an existing case'
+                label='When assigned to a case'
                 toggled={!!settings && settings.assignedExistingCase}
                 onToggle={(evt, isChecked) => this.handleSettingToggled('assignedExistingCase', isChecked)}
               />


### PR DESCRIPTION
See "Set a user's preferences in a scope via MEFE internal API" in Postman for a usage example.
The API can be used with both a `unitId` or a `caseId`, but created with the intention to be used just with `unitId` for now.