### PR TITLE
feat: removed "ready" sub handle usage to prevent retries on failure

### DIFF
--- a/imports/api/base/rest-resource-factory.js
+++ b/imports/api/base/rest-resource-factory.js
@@ -52,7 +52,6 @@ export default ({ collectionName, dataResolver, idResolver = defaultIdResolver }
 
     // Checking if the user is authenticated
     if (!subHandle.userId) {
-      subHandle.ready()
       subHandle.error(new Meteor.Error({ message: 'Authentication required' }))
       return false
     }
@@ -101,7 +100,6 @@ export default ({ collectionName, dataResolver, idResolver = defaultIdResolver }
            in an error:`,
           err
         )
-        subHandle.ready()
         subHandle.error(new Meteor.Error({ message: 'REST API error', origError: err }))
       })
     subHandle.onStop(() => {

--- a/imports/api/base/rest-resource-factory.test.js
+++ b/imports/api/base/rest-resource-factory.test.js
@@ -112,7 +112,7 @@ if (Meteor.isServer) {
         expect(context.added).to.have.been.calledThrice()
         expect(context.ready).to.have.been.calledOnce()
       })
-      it('should use the "ready" and "error" triggers if an API error has occurred', (done) => {
+      it('should use the "error" trigger if an API error has occurred', (done) => {
         const context = {
           userId: 2132,
           error: sinon.spy(),
@@ -125,7 +125,7 @@ if (Meteor.isServer) {
         publishFunc.call(context, 444)
 
         process.nextTick(() => {
-          expect(context.ready).to.have.been.calledOnce()
+          // expect(context.ready).to.have.been.calledOnce()
           expect(context.error).to.have.been.calledOnce()
           done()
         })

--- a/imports/api/case-field-values.js
+++ b/imports/api/case-field-values.js
@@ -14,7 +14,6 @@ const clientLocalFieldMapping = Object.assign({}, caseClientFieldMapping, { bug_
 if (Meteor.isServer) {
   Meteor.publish(`${collectionName}.fetchByName`, function (name) {
     if (!this.userId) {
-      this.ready()
       this.error(new Meteor.Error({ message: 'Authentication required' }))
       return false
     }
@@ -28,7 +27,6 @@ if (Meteor.isServer) {
       this.ready()
     } catch (e) {
       logger.error('API error encountered', e, `${collectionName}.fetchByName`, this.userId)
-      this.ready()
       this.error(new Meteor.Error({ message: 'API Error' }))
     }
   })

--- a/imports/api/case-notifications.js
+++ b/imports/api/case-notifications.js
@@ -31,7 +31,6 @@ Meteor.methods({
 if (Meteor.isServer) {
   Meteor.publish(`${collectionName}.myUpdates`, function () {
     if (!this.userId) {
-      this.ready()
       this.error(new Meteor.Error('Must be logged in first'))
     }
     return CaseNotifications.find({

--- a/imports/api/custom-users.js
+++ b/imports/api/custom-users.js
@@ -28,7 +28,6 @@ export const findOrCreateUser = email => {
 
 const verifyUserLogin = handle => {
   if (!handle.userId) {
-    handle.ready()
     handle.error(new Meteor.Error({ message: 'Authentication required' }))
     return false
   }

--- a/imports/api/pending-invitations.js
+++ b/imports/api/pending-invitations.js
@@ -160,7 +160,6 @@ if (Meteor.isServer) {
     check(caseId, Number)
 
     if (!this.userId) {
-      this.ready()
       this.error('Unauthorized')
       return
     }


### PR DESCRIPTION
Need to be tested slightly further... The "error" and "ready" subscription methods seem to behave differently now than what they did before (probably when we were using an older version of Meteor), and calling "error" alone seems to stop retries