### PR TITLE
New case role selection

### DIFF
--- a/imports/api/units.js
+++ b/imports/api/units.js
@@ -305,7 +305,8 @@ const rolesSelectionByOwnership = (userId, unitItem) => {
       'members.id': userId
     }, {
       fields: {
-        'members.$': 1
+        'members.$': 1,
+        roleType: 1
       }
     })
     const { roleVisibility } = meRole.members[0]
@@ -317,6 +318,10 @@ const rolesSelectionByOwnership = (userId, unitItem) => {
       }
       return all
     }, [])
+
+    if (!types.includes(meRole.roleType)) {
+      types.push(meRole.roleType)
+    }
 
     return {
       roleType: {

--- a/imports/ui/case-wizard/case-wizard.jsx
+++ b/imports/ui/case-wizard/case-wizard.jsx
@@ -96,7 +96,7 @@ class CaseWizard extends Component {
 
   handleRoleChanged = (evt, val) => {
     const { inputValues } = this.state
-    const { default_assigned_to: assignedTo } = this.props.unitItem.components.find(({ name }) => name === val)
+    const needsNewUser = !this.props.availableRoles.find(role => role.type === val).hasDefaultAssignee
 
     this.setState({
       inputValues: Object.assign({}, inputValues, {
@@ -104,7 +104,7 @@ class CaseWizard extends Component {
           assignedUnitRole: val
         })
       }),
-      needsNewUser: placeholderEmailMatcher(assignedTo),
+      needsNewUser,
       newUserCanBeOccupant: roleCanBeOccupantMatcher(val),
       newUserIsOccupant: false
     })

--- a/imports/ui/case-wizard/case-wizard.jsx
+++ b/imports/ui/case-wizard/case-wizard.jsx
@@ -65,7 +65,7 @@ class CaseWizard extends Component {
     }
     const { availableRoles } = this.props
     const { inputValues } = this.state
-    if (availableRoles && prevProps.availableRoles === null) {
+    if (availableRoles.length && !prevProps.availableRoles.length) {
       const defaultRole = availableRoles.find(roleObj => roleObj.assignedToYou).type
       this.setState({
         inputValues: Object.assign({}, inputValues, {

--- a/imports/ui/case-wizard/case-wizard.jsx
+++ b/imports/ui/case-wizard/case-wizard.jsx
@@ -22,7 +22,7 @@ import ErrorDialog from '../dialogs/error-dialog'
 import Preloader from '../preloader/preloader'
 import Units, { collectionName as unitsCollName } from '../../api/units'
 import { createCase, clearError } from './case-wizard.actions'
-import { placeholderEmailMatcher, roleCanBeOccupantMatcher } from '../../util/matchers'
+import { roleCanBeOccupantMatcher } from '../../util/matchers'
 import { emailValidator } from '../../util/validators'
 import InputRow from '../components/input-row'
 import { infoItemMembers } from '../util/static-info-rendering'
@@ -79,11 +79,6 @@ class CaseWizard extends Component {
 
   renderRadioButtons = () => {
     const { unitItem, userId, inProgress, availableRoles } = this.props
-    const roleRenderer = ({ type, assignedToYou }) => (
-      <RadioButton
-        key={type} value={type} label={type + (assignedToYou ? ' (you)' : '')} disabled={inProgress}
-      />
-    )
     let rolesToRender
     if (unitItem.ownerIds && unitItem.ownerIds.includes(userId)) {
       rolesToRender = availableRoles
@@ -92,7 +87,11 @@ class CaseWizard extends Component {
       // The last bool is used in case of no default assignee, but role is assigned to user (not sure if it's possible)
       rolesToRender = availableRoles.filter(role => role.type !== 'Contractor' && (role.hasDefaultAssignee || role.assignedToYou))
     }
-    return rolesToRender.map(roleRenderer)
+    return rolesToRender.map(({ type, assignedToYou }) => (
+      <RadioButton
+        key={type} value={type} label={type + (assignedToYou ? ' (you)' : '')} disabled={inProgress}
+      />
+    ))
   }
 
   handleRoleChanged = (evt, val) => {
@@ -141,7 +140,7 @@ class CaseWizard extends Component {
   }
 
   render () {
-    const { isLoading, fieldValues, unitItem, dispatch, error, inProgress, reportItem } = this.props
+    const { isLoading, fieldValues, unitItem, dispatch, error, inProgress, reportItem, availableRoles } = this.props
     if (isLoading) {
       return <Preloader />
     }
@@ -251,13 +250,23 @@ class CaseWizard extends Component {
               </div>
             </div>
             <p className='pv0 f6 bondi-blue'>Assign this case to *</p>
-            <RadioButtonGroup
-              name='assignedUnitRole'
-              onChange={this.handleRoleChanged}
-              valueSelected={assignedUnitRole}
-            >
-              {this.renderRadioButtons()}
-            </RadioButtonGroup>
+            {availableRoles.length < 2 ? (
+              <p className='f7 gray ma0 mt1'>
+                {
+                  availableRoles.length === 0
+                    ? 'This case can\'t be created as you aren\'t allowed to assign anyone to it'
+                    : `This case will be assigned to${availableRoles[0].assignedToYou ? ' you as' : ''} the ${availableRoles[0].type} of this unit`
+                }
+              </p>
+            ) : (
+              <RadioButtonGroup
+                name='assignedUnitRole'
+                onChange={this.handleRoleChanged}
+                valueSelected={assignedUnitRole}
+              >
+                {this.renderRadioButtons()}
+              </RadioButtonGroup>
+            )}
             {needsNewUser && (
               <div className='mt3'>
                 <p className='mv0 pv0 f7 warn-crimson lh-copy'>


### PR DESCRIPTION
### Features/Fixes
- Prompt instead of radio button if only one role is available for seleciton
![Screenshot from 2019-05-31 17-24-56](https://user-images.githubusercontent.com/2662819/58700128-d9621c80-83d1-11e9-9118-aaec6d2897cd.png)
- (Fix) automatic selection of the user's current role
![Screenshot from 2019-05-31 17-25-59](https://user-images.githubusercontent.com/2662819/58700281-2d6d0100-83d2-11e9-8eee-c53f19618b17.png)

- Always including the user's own role, even if the settings try to hide its own role (avoids unwanted edge cases)
- (Fix) detection of the whether a role has a default assignee before requiring invitation is now based on role information from Mongo and not BZ

See the commits below for more details