### PR TITLE
Custom branded notifications

### DIFF
--- a/imports/email-templates/case-assignee-updated.js
+++ b/imports/email-templates/case-assignee-updated.js
@@ -2,11 +2,11 @@ import url from 'url'
 import { createEngagementLink, getCaseAccessPath } from './components/helpers'
 import notificationEmailLayout from './components/notification-email-layout'
 
-export default (assignee, notificationId, settingType, unitMeta, caseTitle, caseId) => {
+export default (assignee, notificationId, settingType, unitMeta, unitCreator, caseTitle, caseId) => {
   const casePath = getCaseAccessPath(assignee, caseId)
 
   const optOutUrl = createEngagementLink({
-    url: URL.resolve(process.env.ROOT_URL, '/notification-settings'),
+    url: url.resolve(process.env.ROOT_URL, '/notification-settings'),
     id: notificationId,
     email: assignee.emails[0].address
   })
@@ -29,6 +29,7 @@ export default (assignee, notificationId, settingType, unitMeta, caseTitle, case
         You have been assigned the case "${caseTitle}" in ${unitMeta.displayName} at ${unitMeta.streetAddress}.
       `,
       reasonExplanation: 'you have been assigned to a case',
+      unitCreator,
       accessUrl,
       optOutUrl
     })

--- a/imports/email-templates/case-assignee-updated.js
+++ b/imports/email-templates/case-assignee-updated.js
@@ -1,37 +1,36 @@
 import url from 'url'
-import { createEngagementLink, resolveUserName, optOutHtml, optOutText, getCaseAccessPath } from './components/helpers'
+import { createEngagementLink, getCaseAccessPath } from './components/helpers'
+import notificationEmailLayout from './components/notification-email-layout'
 
-export default (assignee, notificationId, settingType, caseTitle, caseId) => {
+export default (assignee, notificationId, settingType, unitMeta, caseTitle, caseId) => {
   const casePath = getCaseAccessPath(assignee, caseId)
+
+  const optOutUrl = createEngagementLink({
+    url: URL.resolve(process.env.ROOT_URL, '/notification-settings'),
+    id: notificationId,
+    email: assignee.emails[0].address
+  })
+
+  const accessUrl = createEngagementLink({
+    url: url.resolve(process.env.ROOT_URL, casePath),
+    id: notificationId,
+    email: assignee.emails[0].address
+  })
+
   return {
-    subject: `Assigned to "${caseTitle}"`,
-    html: `
-  <img src="cid:logo@unee-t.com"/>
-  <p>Hi ${resolveUserName(assignee)},</p>
-  <p>You have been assigned the case <strong>${caseTitle}</strong> in Unee-T.</p>  
-  <p>Please follow <a href='${createEngagementLink({
-    url: url.resolve(process.env.ROOT_URL, casePath),
-    id: notificationId,
-    email: assignee.emails[0].address
-  })}'>${url.resolve(process.env.ROOT_URL, casePath)}</a> to participate.</p>` +
-
-      optOutHtml(settingType, notificationId, assignee),
-    text: `
-
-Hi ${resolveUserName(assignee)},
-
-You have been assigned the case ${caseTitle}.
-
-Please follow ${createEngagementLink({
-    url: url.resolve(process.env.ROOT_URL, casePath),
-    id: notificationId,
-    email: assignee.emails[0].address
-  })} to participate.
-
-  ` + optOutText(settingType, notificationId, assignee),
-    attachments: [{
-      path: 'https://s3-ap-southeast-1.amazonaws.com/prod-media-unee-t/2018-06-14/unee-t_logo_email.png',
-      cid: 'logo@unee-t.com'
-    }]
+    subject: `Assigned to ${caseTitle} in ${unitMeta.displayName} at ${unitMeta.streetAddress}`,
+    ...notificationEmailLayout({
+      typeTitle: 'Case Assigned',
+      user: assignee,
+      mainContentHtml: `
+        <p>You have been assigned the case <strong>${caseTitle}</strong> in ${unitMeta.displayName} at ${unitMeta.streetAddress}.</p>
+      `,
+      mainContentText: `
+        You have been assigned the case "${caseTitle}" in ${unitMeta.displayName} at ${unitMeta.streetAddress}.
+      `,
+      reasonExplanation: 'you have been assigned to a case',
+      accessUrl,
+      optOutUrl
+    })
   }
 }

--- a/imports/email-templates/case-new-message.js
+++ b/imports/email-templates/case-new-message.js
@@ -10,7 +10,7 @@ export default (assignee, notificationId, settingType, unitMeta, caseTitle, case
     email: assignee.emails[0].address
   })
   const optOutUrl = createEngagementLink({
-    url: URL.resolve(process.env.ROOT_URL, '/notification-settings'),
+    url: url.resolve(process.env.ROOT_URL, '/notification-settings'),
     id: notificationId,
     email: assignee.emails[0].address
   })

--- a/imports/email-templates/case-new-message.js
+++ b/imports/email-templates/case-new-message.js
@@ -1,39 +1,37 @@
 import url from 'url'
-import { createEngagementLink, resolveUserName, optOutHtml, optOutText, getCaseAccessPath } from './components/helpers'
+import { createEngagementLink, resolveUserName, getCaseAccessPath } from './components/helpers'
+import notificationEmailLayout from './components/notification-email-layout'
 
-export default (assignee, notificationId, settingType, caseTitle, caseId, user, message) => {
+export default (assignee, notificationId, settingType, unitMeta, caseTitle, caseId, user, message) => {
   const casePath = getCaseAccessPath(assignee, caseId)
+  const accessUrl = createEngagementLink({
+    url: url.resolve(process.env.ROOT_URL, casePath),
+    id: notificationId,
+    email: assignee.emails[0].address
+  })
+  const optOutUrl = createEngagementLink({
+    url: URL.resolve(process.env.ROOT_URL, '/notification-settings'),
+    id: notificationId,
+    email: assignee.emails[0].address
+  })
   return {
-    subject: `New message on case "${caseTitle}"`,
-    html: `
-<img src="cid:logo@unee-t.com"/>
-<p>Hi ${resolveUserName(assignee)},</p>
-<p>New message by ${resolveUserName(user)}:</p>
-<p><strong>${message}</strong></p>
-<p>Please follow <a href='${createEngagementLink({
-    url: url.resolve(process.env.ROOT_URL, casePath),
-    id: notificationId,
-    email: assignee.emails[0].address
-  })}'>${url.resolve(process.env.ROOT_URL, casePath)}</a> to participate.</p>
-  ` + optOutHtml(settingType, notificationId, assignee),
-    text: `
-
-Hi ${resolveUserName(assignee)},
-
-New message by ${resolveUserName(user)}:
-
- > ${message}
-
-  Please follow ${createEngagementLink({
-    url: url.resolve(process.env.ROOT_URL, casePath),
-    id: notificationId,
-    email: assignee.emails[0].address
-  })} to participate.
-
-  ` + optOutText(settingType, notificationId, assignee),
-    attachments: [{
-      path: 'https://s3-ap-southeast-1.amazonaws.com/prod-media-unee-t/2018-06-14/unee-t_logo_email.png',
-      cid: 'logo@unee-t.com'
-    }]
+    subject: `New message on case ${caseTitle} in ${unitMeta.displayName} at ${unitMeta.streetAddress}`,
+    ...notificationEmailLayout({
+      typeTitle: 'New message on a case',
+      user: assignee,
+      mainContentHtml: `
+        <p>New message by ${resolveUserName(user)}:</p>
+        <p><strong>"${message}"</strong></p>
+      `,
+      mainContentText: `
+        New message by ${resolveUserName(user)}:
+        
+        "${message}"
+        
+      `,
+      reasonExplanation: 'you have a new message on a case',
+      accessUrl,
+      optOutUrl
+    })
   }
 }

--- a/imports/email-templates/case-updated.js
+++ b/imports/email-templates/case-updated.js
@@ -6,7 +6,7 @@ export default (assignee, notificationId, settingType, unitMeta, caseTitle, case
   const casePath = getCaseAccessPath(assignee, caseId)
 
   const optOutUrl = createEngagementLink({
-    url: URL.resolve(process.env.ROOT_URL, '/notification-settings'),
+    url: url.resolve(process.env.ROOT_URL, '/notification-settings'),
     id: notificationId,
     email: assignee.emails[0].address
   })

--- a/imports/email-templates/case-updated.js
+++ b/imports/email-templates/case-updated.js
@@ -1,36 +1,37 @@
 import url from 'url'
-import { createEngagementLink, resolveUserName, optOutHtml, optOutText, getCaseAccessPath } from './components/helpers'
+import { createEngagementLink, resolveUserName, getCaseAccessPath } from './components/helpers'
+import notificationEmailLayout from './components/notification-email-layout'
 
-export default (assignee, notificationId, settingType, caseTitle, caseId, updateWhat, user) => {
+export default (assignee, notificationId, settingType, unitMeta, caseTitle, caseId, message, user) => {
   const casePath = getCaseAccessPath(assignee, caseId)
+
+  const optOutUrl = createEngagementLink({
+    url: URL.resolve(process.env.ROOT_URL, '/notification-settings'),
+    id: notificationId,
+    email: assignee.emails[0].address
+  })
+
+  const accessUrl = createEngagementLink({
+    url: url.resolve(process.env.ROOT_URL, casePath),
+    id: notificationId,
+    email: assignee.emails[0].address
+  })
   return {
-    subject: `Case updated "${caseTitle}"`,
-    html: `
-<img src="cid:logo@unee-t.com"/>
-<p>Hi ${resolveUserName(assignee)},</p>
-<p>The case <strong>${caseTitle}</strong> has had a ${updateWhat} made by ${resolveUserName(user)}.</p>
-<p>Please follow <a href='${createEngagementLink({
-    url: url.resolve(process.env.ROOT_URL, casePath),
-    id: notificationId,
-    email: assignee.emails[0].address
-  })}'>${url.resolve(process.env.ROOT_URL, casePath)}</a> to participate.</p>
-  ` + optOutHtml(settingType, notificationId, assignee),
-    text: `
-
-Hi ${resolveUserName(assignee)},
-
-  ${caseTitle} has has a ${updateWhat} made by ${resolveUserName(user)}.
-
-  Please follow ${createEngagementLink({
-    url: url.resolve(process.env.ROOT_URL, casePath),
-    id: notificationId,
-    email: assignee.emails[0].address
-  })} to participate.
-
-  ` + optOutText(settingType, notificationId, assignee),
-    attachments: [{
-      path: 'https://s3-ap-southeast-1.amazonaws.com/prod-media-unee-t/2018-06-14/unee-t_logo_email.png',
-      cid: 'logo@unee-t.com'
-    }]
+    subject: `Case updated ${caseTitle} in ${unitMeta.displayName} at ${unitMeta.streetAddress}`,
+    ...notificationEmailLayout({
+      typeTitle: 'Case updated',
+      user: assignee,
+      mainContentHtml: `
+        <p>
+          The case <strong>${caseTitle}</strong> in ${unitMeta.displayName} at ${unitMeta.streetAddress} has had a change in <strong>${message.update_what}</strong> from <strong>'${message.old_value}'</strong> to <strong>'${message.new_value}'</strong> made by ${resolveUserName(user)}.
+        </p>
+      `,
+      mainContentText: `
+        The case ${caseTitle} in ${unitMeta.displayName} at ${unitMeta.streetAddress} has had a change in ${message.update_what} from '${message.old_value}' to '${message.new_value}' made by ${resolveUserName(user)}.      
+      `,
+      reasonExplanation: 'there has been an update on a case',
+      optOutUrl,
+      accessUrl
+    })
   }
 }

--- a/imports/email-templates/case-user-invited.js
+++ b/imports/email-templates/case-user-invited.js
@@ -6,7 +6,7 @@ export default (invitee, notificationId, settingType, unitMeta, caseTitle, caseI
   const casePath = getCaseAccessPath(invitee, caseId)
 
   const optOutUrl = createEngagementLink({
-    url: URL.resolve(process.env.ROOT_URL, '/notification-settings'),
+    url: url.resolve(process.env.ROOT_URL, '/notification-settings'),
     id: notificationId,
     email: invitee.emails[0].address
   })

--- a/imports/email-templates/case-user-invited.js
+++ b/imports/email-templates/case-user-invited.js
@@ -1,35 +1,38 @@
 import url from 'url'
-import { createEngagementLink, resolveUserName, optOutHtml, optOutText, getCaseAccessPath } from './components/helpers'
+import { createEngagementLink, getCaseAccessPath } from './components/helpers'
+import notificationEmailLayout from './components/notification-email-layout'
 
-export default (invitee, notificationId, settingType, caseTitle, caseId) => {
+export default (invitee, notificationId, settingType, unitMeta, caseTitle, caseId) => {
   const casePath = getCaseAccessPath(invitee, caseId)
+
+  const optOutUrl = createEngagementLink({
+    url: URL.resolve(process.env.ROOT_URL, '/notification-settings'),
+    id: notificationId,
+    email: invitee.emails[0].address
+  })
+
+  const accessUrl = createEngagementLink({
+    url: url.resolve(process.env.ROOT_URL, casePath),
+    id: notificationId,
+    email: invitee.emails[0].address
+  })
+
   return {
     subject: `Collaborate on "${caseTitle}"`,
-    html: `
-<img src="cid:logo@unee-t.com"/>
-<p>Hi ${resolveUserName(invitee)},</p>
-<p>You've been invited to collaborate on a case <strong>${caseTitle}</strong> in Unee-T.</p>
-<p>Please follow <a href='${createEngagementLink({
-    url: url.resolve(process.env.ROOT_URL, casePath),
-    id: notificationId,
-    email: invitee.emails[0].address
-  })}'>${url.resolve(process.env.ROOT_URL, casePath)}</a> to participate.</p>
-
-  ` + optOutHtml(settingType, notificationId, invitee),
-    text: `Hi ${resolveUserName(invitee)},
-
-You've been invited to collaborate on a case ${caseTitle} in Unee-T.
-
-Please follow ${createEngagementLink({
-    url: url.resolve(process.env.ROOT_URL, casePath),
-    id: notificationId,
-    email: invitee.emails[0].address
-  })} to participate.
-
-  ` + optOutText(settingType, notificationId, invitee),
-    attachments: [{
-      path: 'https://s3-ap-southeast-1.amazonaws.com/prod-media-unee-t/2018-06-14/unee-t_logo_email.png',
-      cid: 'logo@unee-t.com'
-    }]
+    ...notificationEmailLayout({
+      typeTitle: 'Collaborate on case',
+      user: invitee,
+      mainContentHtml: `
+        <p>
+          You've been invited to collaborate on the case <strong>${caseTitle}</strong> in ${unitMeta.displayName} at ${unitMeta.streetAddress}.
+        </p>  
+      `,
+      mainContentText: `
+        You've been invited to collaborate on the case ${caseTitle} in ${unitMeta.displayName} at ${unitMeta.streetAddress}.
+      `,
+      reasonExplanation: 'you have been invited to collaborate on a case',
+      optOutUrl,
+      accessUrl
+    })
   }
 }

--- a/imports/email-templates/components/email-responsive-style-tag.js
+++ b/imports/email-templates/components/email-responsive-style-tag.js
@@ -1,0 +1,228 @@
+export default `
+<style>
+    @import url('https://fonts.googleapis.com/css?family=Roboto:400,700&display=swap');
+    /* -------------------------------------
+        GLOBAL RESETS
+    ------------------------------------- */
+
+    /*All the styling goes here*/
+
+    img {
+      border: none;
+      -ms-interpolation-mode: bicubic;
+      max-width: 100%;
+    }
+
+    body {
+      background-color: #f2f2f2;
+      font-family: 'Roboto', sans-serif;
+      -webkit-font-smoothing: antialiased;
+      font-size: 14px;
+      color: #555;
+      line-height: 1.6;
+      margin: 0;
+      padding: 0;
+      -ms-text-size-adjust: 100%;
+      -webkit-text-size-adjust: 100%;
+    }
+
+    table {
+      border-collapse: separate;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+      width: 100%; }
+    table td {
+      font-family: 'Roboto', sans-serif;
+      font-size: 14px;
+      vertical-align: top;
+    }
+
+    /* -------------------------------------
+        BODY & CONTAINER
+    ------------------------------------- */
+
+    .body {
+      background-color: #f2f2f2;
+      width: 100%;
+    }
+
+    /* Set a max-width, and make it display as block so it will automatically stretch to that width, but will also shrink down on a phone or something */
+    .container {
+      display: block;
+      margin: 0 auto !important;
+      /* makes it centered */
+      max-width: 580px;
+      padding: 10px;
+      width: 580px;
+    }
+
+    /* This should also be a block element, so that it will fill 100% of the .container */
+    .content {
+      box-sizing: border-box;
+      display: block;
+      margin: 0 auto;
+      max-width: 580px;
+      padding: 10px;
+    }
+
+    /* -------------------------------------
+        HEADER, FOOTER, MAIN
+    ------------------------------------- */
+    .main {
+      background: #ffffff;
+      border-radius: 5px;
+      width: 100%;
+    }
+
+    .wrapper {
+      box-sizing: border-box;
+      padding: 20px;
+    }
+
+    .content-block {
+      padding-bottom: 10px;
+      padding-top: 10px;
+    }
+
+    .footer {
+      clear: both;
+      margin-top: 10px;
+      text-align: center;
+      width: 100%;
+    }
+    .footer td,
+    .footer p,
+    .footer span,
+    .footer a {
+      color: #999999;
+      font-size: 12px;
+      text-align: center;
+    }
+
+    /* -------------------------------------
+        TYPOGRAPHY
+    ------------------------------------- */
+    p,
+    ul,
+    ol {
+      font-family: 'Roboto', sans-serif;
+      font-size: 14px;
+      font-weight: normal;
+      margin: 0;
+      margin-bottom: 15px;
+    }
+    p li,
+    ul li,
+    ol li {
+      list-style-position: inside;
+      margin-left: 5px;
+    }
+
+    a {
+      color: #3498db;
+      text-decoration: underline;
+    }
+
+    /* -------------------------------------
+        OTHER STYLES THAT MIGHT BE USEFUL
+    ------------------------------------- */
+    .align-right {
+      text-align: right;
+    }
+
+    .powered-by {
+      font-size: 12px;
+      color: #777;
+    }
+    .powered-by a {
+      text-decoration: none;
+    }
+
+    .powered-by a img{
+      width: 52px;
+    }
+
+    hr {
+      border: 0;
+      border-bottom: 1px solid #e8e8e8;
+      margin: 20px 0;
+    }
+
+    /* -------------------------------------
+        RESPONSIVE AND MOBILE FRIENDLY STYLES
+    ------------------------------------- */
+    @media only screen and (max-width: 620px) {
+      table[class=body] p,
+      table[class=body] ul,
+      table[class=body] ol,
+      table[class=body] td,
+      table[class=body] span,
+      table[class=body] a {
+        font-size: 16px !important;
+      }
+      table[class=body] .unsub-instruction,
+      table[class=body] .unsub-instruction a{
+        font-size: 12px !important;
+      }
+      table[class=body] .wrapper,
+      table[class=body] .article {
+        padding: 10px !important;
+      }
+      table[class=body] .content {
+        padding: 0 !important;
+      }
+      table[class=body] .container {
+        padding: 0 !important;
+        width: 100% !important;
+      }
+      table[class=body] .main {
+        border-left-width: 0 !important;
+        border-radius: 0 !important;
+        border-right-width: 0 !important;
+      }
+      table[class=body] .btn table {
+        width: 100% !important;
+      }
+      table[class=body] .btn a {
+        width: 100% !important;
+      }
+    }
+
+    /* -------------------------------------
+        PRESERVE THESE STYLES IN THE HEAD
+    ------------------------------------- */
+    @media all {
+      .apple-link a {
+        color: inherit !important;
+        font-family: inherit !important;
+        font-size: inherit !important;
+        font-weight: inherit !important;
+        line-height: inherit !important;
+        text-decoration: none !important;
+      }
+      .btn-primary table td:hover {
+        background-color: #34495e !important;
+      }
+      .btn-primary a:hover {
+        background-color: #34495e !important;
+        border-color: #34495e !important;
+      }
+    }
+    .logo {
+      width: 103px;
+    }
+    .bottom-explanation {
+      color: #777;
+      font-size: 12px;
+      line-height: 20px;
+    }
+    .unsub-instruction {
+      font-size: 10px;
+      line-height: 20px;
+    }
+
+    .unsub-instruction a {
+      color: #555;
+    }
+  </style>
+`

--- a/imports/email-templates/components/email-responsive-style-tag.js
+++ b/imports/email-templates/components/email-responsive-style-tag.js
@@ -1,6 +1,6 @@
 export default `
 <style>
-    @import url('https://fonts.googleapis.com/css?family=Roboto:400,700&display=swap');
+    @import url("https://fonts.googleapis.com/css?family=Roboto:400,700&display=swap");
     /* -------------------------------------
         GLOBAL RESETS
     ------------------------------------- */

--- a/imports/email-templates/components/notification-email-layout.js
+++ b/imports/email-templates/components/notification-email-layout.js
@@ -1,0 +1,103 @@
+import emailResponsiveStyleTag from './email-responsive-style-tag'
+import { resolveUserName } from './helpers'
+
+export default ({ typeTitle, user, mainContentHtml, mainContentText, accessUrl, optOutUrl, reasonExplanation }) => ({
+  html: `
+    <!doctype html>
+<html>
+<head>
+  <meta name="viewport" content="width=device-width" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title>${typeTitle}- Notification Email</title>
+  ${emailResponsiveStyleTag}
+</head>
+<body class="">
+
+<!--<span class="preheader">This is preheader text. Some clients will show this text as a preview.</span>-->
+<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body">
+  <tr>
+    <td>&nbsp;</td>
+    <td class="container">
+      <div class="content">
+
+        <!-- START CENTERED WHITE CONTAINER -->
+        <table role="presentation" class="main">
+
+          <!-- START MAIN CONTENT AREA -->
+          <tr>
+            <td class="wrapper">
+              <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td>
+                    <div class="align-right">
+                      <img class="logo" src="cid:logo@unee-t.com"/>
+                    </div>
+                    <p>Hi ${resolveUserName(user)}</p>
+                    {mainContentHtml}
+                    <p>
+                      Click on this <a href="${accessUrl}">link</a> to see the current status for this case.<br />
+                      Participate in the conversation, add comments or pictures directly so we can resolve this faster.
+                    </p>
+                    <p>
+                      Regards,<br />
+                      Unee-T<br />
+                      THE Web App to Manage Incidents in your Properties
+                    </p>
+                    <hr />
+                    <div class="bottom-explanation">
+                      You are receiving this email because ${reasonExplanation}.
+                    </div>
+                    <div class="unsub-instruction">
+                      <a href="${optOutUrl}">Unsubscribe</a> from these type of emails. <a href="${optOutUrl}">Manage your settings</a> for all type of email updates
+                    </div>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- END MAIN CONTENT AREA -->
+        </table>
+        <!-- END CENTERED WHITE CONTAINER -->
+
+        <!-- START FOOTER -->
+        <div class="footer">
+          <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+            <tr>
+              <td class="content-block powered-by">
+                Powered by <a href="https://unee-t.com"><img src="cid:logo@unee-t.com"/></a>.
+              </td>
+            </tr>
+          </table>
+        </div>
+        <!-- END FOOTER -->
+
+      </div>
+    </td>
+    <td>&nbsp;</td>
+  </tr>
+</table>
+</body>
+</html>
+`,
+
+  text: `
+Hi ${resolveUserName(user)},
+
+${mainContentText}
+
+Follow this link: "${accessUrl}" to see the current status for this case.
+Participate in the conversation, add comments or pictures directly so we can resolve this faster.
+
+Regards,
+Unee-T
+THE Web App to Manage Incidents in your Properties
+--
+You are receiving this email because you have been assigned to a case.
+To Unsubscribe from these type of emails or manage your settings for all type of email updates, go to ${optOutUrl}
+  `,
+  attachments: [{
+    path: 'https://s3-ap-southeast-1.amazonaws.com/prod-media-unee-t/2018-06-14/unee-t_logo_email.png',
+    cid: 'logo@unee-t.com'
+  }]
+})

--- a/imports/email-templates/components/notification-email-layout.js
+++ b/imports/email-templates/components/notification-email-layout.js
@@ -1,8 +1,43 @@
 import emailResponsiveStyleTag from './email-responsive-style-tag'
 import { resolveUserName } from './helpers'
 
-export default ({ typeTitle, user, mainContentHtml, mainContentText, accessUrl, optOutUrl, reasonExplanation }) => ({
-  html: `
+export default ({ typeTitle, user, mainContentHtml, mainContentText, accessUrl, optOutUrl, reasonExplanation, unitCreator }) => {
+  const customConfig = (unitCreator && unitCreator.customEmailBrandingConfig) || {
+    logoUrl: null,
+    brandName: null,
+    signatureHtml: null,
+    signatureText: null
+  }
+
+  const attachments = [{
+    path: 'https://s3-ap-southeast-1.amazonaws.com/prod-media-unee-t/2018-06-14/unee-t_logo_email.png',
+    cid: 'logo@unee-t.com'
+  }]
+
+  if (customConfig.logoUrl) {
+    attachments.push({
+      path: customConfig.logoUrl,
+      cid: 'customlogo@unee-t.com'
+    })
+  }
+
+  const uneetTagLine = 'THE Web App to Manage Incidents in your Properties'
+  const signatureHtml = customConfig.signatureHtml || `
+    <p>
+      Regards,<br />
+      Unee-T<br />
+      ${uneetTagLine}
+    </p>
+  `
+
+  const signatureText = customConfig.signatureText || `
+    Regards,
+    Unee-T
+    ${uneetTagLine}
+  `
+
+  return {
+    html: `
     <!doctype html>
 <html>
 <head>
@@ -30,19 +65,15 @@ export default ({ typeTitle, user, mainContentHtml, mainContentText, accessUrl, 
                 <tr>
                   <td>
                     <div class="align-right">
-                      <img class="logo" src="cid:logo@unee-t.com"/>
+                      <img class="logo" src="${customConfig.logoUrl ? 'cid:customlogo@unee-t.com' : 'cid:logo@unee-t.com'}"/>
                     </div>
                     <p>Hi ${resolveUserName(user)}</p>
-                    {mainContentHtml}
+                    ${mainContentHtml}
                     <p>
                       Click on this <a href="${accessUrl}">link</a> to see the current status for this case.<br />
                       Participate in the conversation, add comments or pictures directly so we can resolve this faster.
                     </p>
-                    <p>
-                      Regards,<br />
-                      Unee-T<br />
-                      THE Web App to Manage Incidents in your Properties
-                    </p>
+                    ${signatureHtml}
                     <hr />
                     <div class="bottom-explanation">
                       You are receiving this email because ${reasonExplanation}.
@@ -65,7 +96,8 @@ export default ({ typeTitle, user, mainContentHtml, mainContentText, accessUrl, 
           <table role="presentation" border="0" cellpadding="0" cellspacing="0">
             <tr>
               <td class="content-block powered-by">
-                Powered by <a href="https://unee-t.com"><img src="cid:logo@unee-t.com"/></a>.
+                <div>Powered by <a href="https://unee-t.com"><img src="cid:logo@unee-t.com"/></a>.</div>
+                ${customConfig.signatureHtml ? `<div>Unee-T: ${uneetTagLine}</div>` : ''}
               </td>
             </tr>
           </table>
@@ -81,7 +113,7 @@ export default ({ typeTitle, user, mainContentHtml, mainContentText, accessUrl, 
 </html>
 `,
 
-  text: `
+    text: `
 Hi ${resolveUserName(user)},
 
 ${mainContentText}
@@ -89,15 +121,14 @@ ${mainContentText}
 Follow this link: "${accessUrl}" to see the current status for this case.
 Participate in the conversation, add comments or pictures directly so we can resolve this faster.
 
-Regards,
-Unee-T
-THE Web App to Manage Incidents in your Properties
+${signatureText}
 --
 You are receiving this email because you have been assigned to a case.
 To Unsubscribe from these type of emails or manage your settings for all type of email updates, go to ${optOutUrl}
-  `,
-  attachments: [{
-    path: 'https://s3-ap-southeast-1.amazonaws.com/prod-media-unee-t/2018-06-14/unee-t_logo_email.png',
-    cid: 'logo@unee-t.com'
-  }]
-})
+${customConfig.signatureText ? `
+Unee-t: ${uneetTagLine}
+` : ''}
+    `,
+    attachments
+  }
+}


### PR DESCRIPTION
This PR includes both the changes for email notifications design in general, and the option for custom branded email notifications.

This is how an email notification looks with default branding:
![Screenshot from 2019-06-06 23-28-53](https://user-images.githubusercontent.com/2662819/59047003-9c0bfc00-88b5-11e9-8aa8-124d71691487.png)

And this is how an email notification looks with custom hmlet branding:
![Screenshot from 2019-06-06 23-43-55](https://user-images.githubusercontent.com/2662819/59047028-a9c18180-88b5-11e9-9b65-538835e7185f.png)

To enable custom branding, the user Mongo document of the unit's **creator** needs to include the following object:
```
{
  ...
  "customEmailBrandingConfig" : {
	"logoUrl" : String,
	"brandName" : String,
	"signatureHtml" : String,
	"signatureText" : String
  }
}
```

For example:
```
"customEmailBrandingConfig" : {
  "logoUrl" : "https://www.hmlet.com/static/images/logos/logo_black.png",
  "brandName" : "hmlet",
  "signatureHtml" : "<p>Cheers,<br />Your friends at hmlet",
  "signatureText" : "Cheers, your friends at hmlet"
}
```

Resolves #814 
Resolves #815 