### PR TITLE
Assign user redesign

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -5,8 +5,10 @@
 .*/.meteor/local/build/programs/server/npm/.*
 .*/.meteor/local/build/programs/server/node_modules/.*
 .*/.meteor/local/build/programs/web.browser/app/.*
+.*/.meteor/local/plugin-cache/.*
 .*/.meteor/local/build/main.js
 .*/.meteor/packages/.*
+
 
 # This package can give you a lot of flow errors, better ignore it
 .*/node_modules/fbjs/.*

--- a/imports/api/units.js
+++ b/imports/api/units.js
@@ -118,6 +118,7 @@ export const getUnitRoles = (unit, userId) => {
             email: user.emails[0].address,
             name: user.profile.name,
             role: roleObj.roleType,
+            isDefaultAssignee: roleObj.defaultAssigneeId === user._id,
             isOccupant: memberDesc.isOccupant,
             avatarUrl: user.profile.avatarUrl
           })
@@ -139,7 +140,8 @@ export const getUnitRoles = (unit, userId) => {
       if (assigned) {
         all.push({
           login: assigned,
-          role: name
+          role: name,
+          isDefaultAssignee: true
         })
       }
       return all
@@ -155,7 +157,8 @@ export const getUnitRoles = (unit, userId) => {
       .map(({ receivedInvites: [{ role, isOccupant }], bugzillaCreds: { login } }) => ({
         login,
         role,
-        isOccupant
+        isOccupant,
+        isDefaultAssignee: false
       }))
     ),
     ({ login }) => login // Filtering out duplicates in case a user shows up in a component and has a finalized invitation

--- a/imports/ui/case/case-details.jsx
+++ b/imports/ui/case/case-details.jsx
@@ -147,9 +147,6 @@ class CaseDetails extends Component {
   renderAssignedTo = (assignedUser, normalizedUnitUsers, pendingInvitations, isUnitOwner, unitRoleType) => {
     const { match, invitationState, onResetInvitation, onNewUserAssigned, onExistingUserAssigned } = this.props
     const { chosenAssigned } = this.state
-    // const defaultAssignees = normalizedUnitUsers.filter(u => u.isDefaultAssignee)
-    // console.log({defaultAssignees})
-
     const pendingUsers = pendingInvitations.map(inv => {
       const { bugzillaCreds: { login }, profile: { name }, emails: [{ address: email }] } = inv.inviteeUser()
       return {
@@ -167,9 +164,9 @@ class CaseDetails extends Component {
       if (user.login === resolvedAssignedUser.login) {
         classes.assignee = user
       } else if (user.isDefaultAssignee) {
-        // classes.defaultRoleAssignees.push(user)
+        classes.defaultRoleAssignees.push(user)
       } else {
-        // classes.otherRoleMembers.push(user)
+        classes.otherRoleMembers.push(user)
       }
 
       return classes

--- a/imports/ui/case/case-details.jsx
+++ b/imports/ui/case/case-details.jsx
@@ -16,6 +16,7 @@ import EditableItem from '../components/editable-item'
 import ErrorDialog from '../dialogs/error-dialog'
 import { infoItemLabel, infoItemMembers, InfoItemContainer, InfoItemRow } from '../util/static-info-rendering'
 import AddUserControlLine from '../components/add-user-control-line'
+import AssigneeSelectionList from '../components/assignee-selection-list'
 
 const mediaItemsPadding = 4 // Corresponds with the classNames set to the media items
 const mediaItemRowCount = 3
@@ -146,6 +147,9 @@ class CaseDetails extends Component {
   renderAssignedTo = (assignedUser, normalizedUnitUsers, pendingInvitations, isUnitOwner, unitRoleType) => {
     const { match, invitationState, onResetInvitation, onNewUserAssigned, onExistingUserAssigned } = this.props
     const { chosenAssigned } = this.state
+    // const defaultAssignees = normalizedUnitUsers.filter(u => u.isDefaultAssignee)
+    // console.log({defaultAssignees})
+
     const pendingUsers = pendingInvitations.map(inv => {
       const { bugzillaCreds: { login }, profile: { name }, emails: [{ address: email }] } = inv.inviteeUser()
       return {
@@ -158,6 +162,22 @@ class CaseDetails extends Component {
     })
     const resolvedAssignedUser = pendingUsers.find(u => u.type === TYPE_ASSIGNED) || assignedUser
     const resolvedChosenAssigned = chosenAssigned || resolvedAssignedUser
+
+    const usersClassifications = normalizedUnitUsers.reduce((classes, user) => {
+      if (user.login === resolvedAssignedUser.login) {
+        classes.assignee = user
+      } else if (user.isDefaultAssignee) {
+        // classes.defaultRoleAssignees.push(user)
+      } else {
+        // classes.otherRoleMembers.push(user)
+      }
+
+      return classes
+    }, {
+      assignee: null,
+      defaultRoleAssignees: [],
+      otherRoleMembers: []
+    })
     return (
       <InfoItemContainer>
         {infoItemLabel('Assigned to:')}
@@ -179,25 +199,13 @@ class CaseDetails extends Component {
           onMainOperation={() => onExistingUserAssigned(chosenAssigned)}
           additionalOperationText='Assign to someone else'
           potentialInvitees={normalizedUnitUsers.concat(pendingUsers.map(u => Object.assign({ pending: true }, u)))}
-          selectControlsRenderer={({ users, inputRefFn }) => (
-            <UsersSearchList
-              users={users}
-              onUserClick={user => this.setState({ chosenAssigned: user })}
-              searchInputRef={inputRefFn}
-              userClassNames={user => user.login === resolvedChosenAssigned.login ? 'bg-very-light-gray' : ''}
-              emptyListMessage={'We couldn\'t find any existing users to assign'}
-              userStatusRenderer={user => {
-                if (user.pending) {
-                  return (
-                    <span className='f7 silver i'>Pending</span>
-                  )
-                }
-                if (user.login === resolvedAssignedUser.login) {
-                  return (
-                    <span className='f7 gray b'>Assigned</span>
-                  )
-                }
-              }}
+          selectControlsRenderer={() => (
+            <AssigneeSelectionList
+              currentAssignee={usersClassifications.assignee}
+              defaultAssignees={usersClassifications.defaultRoleAssignees}
+              otherUsers={usersClassifications.otherRoleMembers}
+              currentSelectedUser={resolvedChosenAssigned}
+              onUserClicked={user => this.setState({ chosenAssigned: user })}
             />
           )}
         />

--- a/imports/ui/components/assignee-selection-list.js
+++ b/imports/ui/components/assignee-selection-list.js
@@ -1,0 +1,70 @@
+// @flow
+import * as React from 'react'
+import UserMenuItem from './user-menu-item'
+import type { UserDetails } from './user-menu-item'
+
+type Props = {
+  currentAssignee: UserDetails,
+  defaultAssignees: Array<UserDetails>,
+  otherUsers: Array<UserDetails>,
+  onUserClicked: (user: UserDetails) => void,
+  currentSelectedUser: ?UserDetails
+}
+
+export default class AssigneeSelectionList extends React.Component<Props> {
+
+  renderUserItem = (user: UserDetails, key?: number | string) => {
+    const { currentAssignee, onUserClicked, currentSelectedUser } = this.props
+    return (
+      <UserMenuItem
+        key={key}
+        onClick={() => onUserClicked(user)}
+        statusComponent={currentAssignee === user ? (<span className='f7 gray b'>Assigned</span>) : null}
+        innerDivExtraClasses={currentSelectedUser && user.login === currentSelectedUser.login ? 'bg-very-light-gray' : ''}
+        user={user}
+      />
+    )
+  }
+  render () {
+    const { currentAssignee, defaultAssignees, otherUsers } = this.props
+    return (
+      <div className='ba b--moon-gray flex-grow h5 overflow-auto'>
+        <div className='pa1'>
+          <div>
+            {this.renderUserItem(currentAssignee)}
+          </div>
+          {defaultAssignees.length || otherUsers.length ? (
+            <div>
+              {defaultAssignees.length > 0 && (
+                <div className='bt b--moon-gray'>
+                  <div className='f7 gray b pt2 pl2'>
+                    Default assignees
+                  </div>
+                  <ul className='list mv0 pa0 pt1'>
+                    {defaultAssignees.map(this.renderUserItem)}
+                  </ul>
+                </div>
+              )}
+              {otherUsers.length > 0 && (
+                <div className='bt b--moon-gray'>
+                  <div className='f7 gray b pt2 pl2'>
+                    Other people associated with this unit
+                  </div>
+                  <ul className='list mv0 pa0 pt1'>
+                    {otherUsers.map(this.renderUserItem)}
+                  </ul>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className='bt b--moon-gray'>
+              <p className='tc f6 i warn-crimson'>
+                We couldn't find any other existing users to assign
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
+}

--- a/imports/ui/components/assignee-selection-list.js
+++ b/imports/ui/components/assignee-selection-list.js
@@ -12,7 +12,6 @@ type Props = {
 }
 
 export default class AssigneeSelectionList extends React.Component<Props> {
-
   renderUserItem = (user: UserDetails, key?: number | string) => {
     const { currentAssignee, onUserClicked, currentSelectedUser } = this.props
     return (

--- a/imports/ui/components/user-menu-item.js
+++ b/imports/ui/components/user-menu-item.js
@@ -1,0 +1,51 @@
+// @flow
+import * as React from 'react'
+import { resetMenuItemDivStyle } from '../general.mui-styles'
+import { getColorForUser } from '../../util/user'
+import UserAvatar from './user-avatar'
+import MenuItem from 'material-ui/MenuItem'
+
+export type UserDetails = {
+  avatarUrl?: string,
+  pending?: boolean,
+  role: string,
+  name?: string,
+  login?: string,
+  email?: string
+}
+
+type Props = {
+  onClick: () => any,
+  innerDivExtraClasses?: string,
+  statusComponent?: React.Node,
+  user: UserDetails
+}
+
+export default class UserMenuItem extends React.Component<Props> {
+  render () {
+    const { onClick, innerDivExtraClasses, user, statusComponent } = this.props
+
+    return (
+      <MenuItem {...{ onClick }} innerDivStyle={resetMenuItemDivStyle}>
+        <div className={
+          getColorForUser(user) + ' flex pv2 ph2 lh-title ' + (innerDivExtraClasses || '')
+        }>
+          <div className='ml1'>
+            <UserAvatar user={user} imageUrl={user.avatarUrl} />
+          </div>
+          <div className='ml2 flex-grow overflow-hidden'>
+            <div className={'f5 ellipsis ' + (user.pending ? 'i silver' : 'bondi-blue')}>
+              { user.name || (user.login && user.login.split('@')[0]) }
+            </div>
+            <div className='f7 gray ellipsis'>{user.role}</div>
+          </div>
+          {statusComponent && (
+            <div className='ml2 flex flex-column justify-center'>
+              {statusComponent}
+            </div>
+          )}
+        </div>
+      </MenuItem>
+    )
+  }
+}

--- a/imports/ui/components/user-selection-box.jsx
+++ b/imports/ui/components/user-selection-box.jsx
@@ -1,10 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import MenuItem from 'material-ui/MenuItem'
-import UserAvatar from './user-avatar'
-
-import { resetMenuItemDivStyle } from '../general.mui-styles'
-import { getColorForUser } from '/imports/util/user'
+import UserMenuItem from './user-menu-item'
 
 const UserSelectionBox = ({ usersList, userStatusRenderer, userClassNames, onUserClick, emptyListMessage }) => (
   <div className='ba b--moon-gray flex-grow h5 overflow-auto'>
@@ -12,30 +8,14 @@ const UserSelectionBox = ({ usersList, userStatusRenderer, userClassNames, onUse
       {usersList.length ? (
         <ul className='list mv0 pa0 pt1 min-h-3'>
           {usersList.map((user, idx) => {
-            const userStatusComp = userStatusRenderer && userStatusRenderer(user)
+            const statusComponent = userStatusRenderer && userStatusRenderer(user)
             const extraClasses = userClassNames ? userClassNames(user) : ''
-            const emailId = user.login.split('@')[0]
             return (
-              <MenuItem key={idx} onClick={() => onUserClick(user)} innerDivStyle={resetMenuItemDivStyle}>
-                <div className={
-                  getColorForUser(user) + ' flex pv2 ph2 lh-title ' + extraClasses
-                }>
-                  <div className='ml1'>
-                    <UserAvatar user={user} imageUrl={user.avatarUrl} />
-                  </div>
-                  <div className='ml2 flex-grow overflow-hidden'>
-                    <div className={'f5 ellipsis ' + (user.pending ? 'i silver' : 'bondi-blue')}>
-                      { user.name || emailId }
-                    </div>
-                    <div className='f7 gray ellipsis'>{user.role}</div>
-                  </div>
-                  {userStatusComp && (
-                    <div className='ml2 flex flex-column justify-center'>
-                      {userStatusComp}
-                    </div>
-                  )}
-                </div>
-              </MenuItem>
+              <UserMenuItem key={idx}
+                onClick={() => onUserClick(user)}
+                innerDivExtraClasses={extraClasses}
+                {...{ user, statusComponent }}
+              />
             )
           })}
         </ul>


### PR DESCRIPTION
Resolves #823 

![Screenshot from 2019-06-21 18-03-26](https://user-images.githubusercontent.com/2662819/59915541-718e7700-944f-11e9-8367-2c6256eb838e.png)
![Screenshot from 2019-06-21 18-04-08](https://user-images.githubusercontent.com/2662819/59915543-718e7700-944f-11e9-9a75-fca370088903.png)
![Screenshot from 2019-06-21 18-04-44](https://user-images.githubusercontent.com/2662819/59915544-718e7700-944f-11e9-8f3a-e0f30914a032.png)

The screenshots above show the 3 corresponding scenarios:
- There are no users associated with roles on this unit aside from the current assignee.
- The only users associated with roles on this unit are the current assignee and the default assignees for the visible roles.
- There are some users associated with the roles on this unit as default assignees and some who are associated as "standard" members.