### PR TITLE
Create case api auth header

### DIFF
--- a/imports/api/rest/middleware/user-api-key-middleware.js
+++ b/imports/api/rest/middleware/user-api-key-middleware.js
@@ -20,8 +20,6 @@ export const headerExtractor:Extractor = {
     const authHeader = req.headers.Authorization || req.headers.authorization
     if (authHeader) {
       const match = authHeader.match(/Bearer (.+)/)
-      console.log({match1: match[1]})
-
       if (match) return match[1]
     }
   },

--- a/imports/api/rest/middleware/user-api-key-middleware.js
+++ b/imports/api/rest/middleware/user-api-key-middleware.js
@@ -4,7 +4,7 @@ import { logger } from '../../../util/logger'
 import type { Request, Response, NextFunc } from '../rest-types'
 
 type Extractor = {
-  func: (req:Request) => string|null,
+  func: (req:Request) => ?string,
   errorMsg: string
 }
 export const queryExtractor:Extractor = {
@@ -15,10 +15,34 @@ export const bodyExtractor:Extractor = {
   func: req => req.body.apiKey,
   errorMsg: '"apiKey" must be provided in the request\'s body'
 }
+export const headerExtractor:Extractor = {
+  func: req => {
+    const authHeader = req.headers.Authorization || req.headers.authorization
+    if (authHeader) {
+      const match = authHeader.match(/Bearer (.+)/)
+      console.log({match1: match[1]})
+
+      if (match) return match[1]
+    }
+  },
+  errorMsg: '"apiKey" must be provided in the request\'s headers as an "Authorization: Bearer..." token'
+}
+export const makeComposedExtractor = (...extractors: Array<Extractor>):Extractor => ({
+  func: req => {
+    let apiKey
+    return extractors.some(ext =>{
+      apiKey = ext.func(req)
+      return apiKey
+    }) ? apiKey : null
+  },
+  errorMsg: 'The request must fulfill one of the following: ' + extractors.map(ext => ext.errorMsg).join('; ')
+})
+
 export const retrieveKey = (keyStr: string) => {
   const user = Meteor.users.findOne({
     'mefeApiKeys.key': keyStr
   })
+
   const obfuscatedKey = `${keyStr.slice(0, 3)}***${keyStr.slice(-3)}`
   if (!user) {
     logger.warn(`No user found for apiKey ${obfuscatedKey}`)

--- a/imports/api/rest/middleware/user-api-key-middleware.js
+++ b/imports/api/rest/middleware/user-api-key-middleware.js
@@ -28,7 +28,7 @@ export const headerExtractor:Extractor = {
 export const makeComposedExtractor = (...extractors: Array<Extractor>):Extractor => ({
   func: req => {
     let apiKey
-    return extractors.some(ext =>{
+    return extractors.some(ext => {
       apiKey = ext.func(req)
       return apiKey
     }) ? apiKey : null

--- a/imports/api/rest/post-cases.js
+++ b/imports/api/rest/post-cases.js
@@ -1,6 +1,6 @@
 // @flow
 import { Meteor } from 'meteor/meteor'
-import userApiKey, { bodyExtractor } from './middleware/user-api-key-middleware'
+import userApiKey, { bodyExtractor, headerExtractor, makeComposedExtractor } from './middleware/user-api-key-middleware'
 import { check, Match } from 'meteor/check'
 import { logger } from '../../util/logger'
 import { createCase } from '../cases'
@@ -190,4 +190,4 @@ export default userApiKey((req: Request, res: Response) => {
   }
 
   res.send(200, { id: newCaseId })
-}, bodyExtractor)
+}, makeComposedExtractor(bodyExtractor, headerExtractor))


### PR DESCRIPTION
This PR allows to specify the apiKey as an authorization bearer header for the create case API like so:
`Authorizarion: Bearer xxxxxxxxx`