### PR TITLE
Revamped file input file selection

### DIFF
--- a/imports/ui/components/file-input.jsx
+++ b/imports/ui/components/file-input.jsx
@@ -1,6 +1,7 @@
 // @flow
 /* global SyntheticInputEvent, HTMLInputElement */
 import * as React from 'react'
+import ErrorDialog from '../dialogs/error-dialog'
 
 type Props = {
   children: React.Node,
@@ -11,21 +12,43 @@ type Props = {
   onFileSelected: (evt: SyntheticInputEvent<HTMLInputElement>) => void
 }
 
-export default class FileInput extends React.Component<Props> {
-  render () {
-    const acceptTypes = this.props.acceptTypes || { image: true, audio: false }
-    let acceptStrs = []
-    if (acceptTypes) {
-      acceptStrs.push('audio/*')
-    }
-    if (acceptTypes.image) {
-      acceptStrs.push('image/*')
-    }
+type State = {
+  typeError: boolean
+}
 
+export default class FileInput extends React.Component<Props, State> {
+  state = {
+    typeError: false
+  }
+  handleFileSelected = (evt: SyntheticInputEvent<HTMLInputElement>) => {
+    const fileType = evt.target.files[0].type.split('/')[0]
+    if (this.allowedTypes.includes(fileType)) {
+      this.props.onFileSelected(evt)
+    } else {
+      evt.preventDefault()
+      this.setState({
+        typeError: true
+      })
+    }
+  }
+
+  get allowedTypes ():Array<string> {
+    const acceptTypes = this.props.acceptTypes || { image: true, audio: false }
+    return Object.keys(acceptTypes).filter(type => !!acceptTypes[type])
+  }
+
+  render () {
     return (
       <label>
         {this.props.children}
-        <input type='file' accept={acceptStrs.join(', ')} capture='filesystem' className='dn' onChange={this.props.onFileSelected} />
+        <input type='file' className='dn' onChange={this.handleFileSelected} />
+        <ErrorDialog
+          show={this.state.typeError}
+          text={`The file type you selected is not supported for this input. The supported type${
+            this.allowedTypes.length === 1 ? ` is "${this.allowedTypes[0]}"` : `s are "${this.allowedTypes.join('", "')}"`
+          }`}
+          onDismissed={() => this.setState({ typeError: false })}
+        />
       </label>
     )
   }


### PR DESCRIPTION
This was made to follow up on changes made to restrict file type selection, but made issues for some users on some devices to select files normally.
The file selection now lists all files again, but if an invalid type is chosen, it shows an error message.

![Screenshot from 2019-08-08 18-36-11](https://user-images.githubusercontent.com/2662819/62700572-dcead300-ba14-11e9-913c-f550ba17b6ff.png)
![Screenshot from 2019-08-08 18-36-57](https://user-images.githubusercontent.com/2662819/62700574-dcead300-ba14-11e9-9c2a-e52596bcb322.png)
