### PR TITLE
Dialogs to edit solution and next steps and deadline dates

### DIFF
--- a/client/main.css
+++ b/client/main.css
@@ -68,6 +68,10 @@
   color: var(--success-green);
 }
 
+.very-light-gray {
+  color: var(--very-light-gray);
+}
+
 .semi-dark-gray {
   color: var(--semi-dark-gray);
 }
@@ -170,6 +174,7 @@
 .h3 { height: 4rem; }
 .h4 { height: 8rem; }
 .h5 { height: 16rem; }
+.h6 { height: 32rem; }
 
 /* custom addition */
 .h40px { height: 40px; }

--- a/imports/api/cases.js
+++ b/imports/api/cases.js
@@ -683,7 +683,9 @@ Meteor.methods({
     editableFields: [
       'title',
       'solution',
+      'solutionDeadline',
       'nextSteps',
+      'nextStepsBy',
       'status',
       'resolution',
       'category',

--- a/imports/ui/case/case.jsx
+++ b/imports/ui/case/case.jsx
@@ -305,9 +305,7 @@ const MobileHeader = props => {
         )
       }} />
       <Route path={match.url} render={routeProps => (
-        <InnerAppBar
-          title={caseItem.title} onBack={() => handleBack()}
-        />
+        <InnerAppBar title={caseItem.title} onBack={() => handleBack()} />
       )} />
     </Switch>
   )

--- a/imports/ui/components/editable-item.jsx
+++ b/imports/ui/components/editable-item.jsx
@@ -34,9 +34,13 @@ export default class EditableItem extends Component {
     this.props.onEdit(value)
   }
   render () {
-    const { label, isMultiLine, selectionList, disabled, name, underlineShow, inpRef } = this.props
+    const { label, isMultiLine, selectionList, disabled, name, underlineShow, inpRef, rowsMax } = this.props
     const { value } = this.state
 
+    const optionalAttrs = {}
+    if (rowsMax) {
+      optionalAttrs.rowsMax = rowsMax
+    }
     if (!selectionList) {
       return (
         <StickyTextField
@@ -52,6 +56,7 @@ export default class EditableItem extends Component {
           value={value}
           inpRef={inpRef}
           onChange={({ target: { value } }) => this.handleEdit(value)}
+          {...optionalAttrs}
         />
       )
     } else {
@@ -84,6 +89,7 @@ EditableItem.propTypes = {
   currentValue: PropTypes.string,
   selectionList: PropTypes.array,
   disabled: PropTypes.bool,
+  rowsMax: PropTypes.number,
   inpRef: PropTypes.func, // relevant only if "selectionList" is undefined
   underlineShow: PropTypes.bool // relevant only if "selectionList" is undefined
 }

--- a/imports/ui/dialogs/case-target-attr-dialog.jsx
+++ b/imports/ui/dialogs/case-target-attr-dialog.jsx
@@ -114,7 +114,7 @@ export default class CaseTargetAttrDialog extends React.Component<Props, State> 
             <FontIcon className='material-icons' style={closeDialogButtonStyle}>close</FontIcon>
           </IconButton>
         </div>
-        <div className='flex flex-column h6'>
+        <div className='flex flex-column h6 overflow-auto'>
           <EditableItem
             isMultiLine
             label={attrName}

--- a/imports/ui/dialogs/case-target-attr-dialog.jsx
+++ b/imports/ui/dialogs/case-target-attr-dialog.jsx
@@ -30,7 +30,8 @@ type State = {
   attrValue: string,
   attrDate: ?Date,
   attrTime: any,
-  isEditing: boolean
+  isEditing: boolean,
+  hideDateRow: boolean
 }
 
 const displayTextFieldStyle = {
@@ -43,7 +44,8 @@ export default class CaseTargetAttrDialog extends React.Component<Props, State> 
     attrValue: '',
     attrDate: null,
     attrTime: null,
-    isEditing: false
+    isEditing: false,
+    hideDateRow: false
   }
 
   componentDidMount () {
@@ -95,19 +97,29 @@ export default class CaseTargetAttrDialog extends React.Component<Props, State> 
     this.props.onSubmit(attrValue, finalDateTime.toDate())
   }
 
+  handleHeightChanged = (height: number) => {
+    const { hideDateRow } = this.state
+    if (hideDateRow !== (height < 300)) {
+      this.setState({
+        hideDateRow: height < 300
+      })
+    }
+  }
+
   render () {
     const { show, onCancel, attrName, showTime } = this.props
-    const { attrValue, attrDate, attrTime, isEditing } = this.state
+    const { attrValue, attrDate, attrTime, isEditing, hideDateRow } = this.state
     const now = new Date()
     return (
       <HeightHackDialog
-        padding={100}
+        padding={50}
         open={show}
         title={(isEditing ? 'Edit ' : 'Create ') + attrName}
         bodyStyle={modalBodyStyle}
         contentStyle={modalCustomContentStyle}
         titleStyle={customTitleStyle}
         onRequestClose={onCancel}
+        onHeightChange={this.handleHeightChanged}
       >
         <div className='absolute top-1 right-1'>
           <IconButton onClick={onCancel}>
@@ -120,43 +132,46 @@ export default class CaseTargetAttrDialog extends React.Component<Props, State> 
             label={attrName}
             onEdit={val => { this.setState({ attrValue: val }) }}
             currentValue={attrValue}
+            rowsMax={3}
           />
           <div className='mt3 flex-grow'>
-            {infoItemLabel('Deadline')}
-            <div className='flex'>
-              <div className='flex-grow flex items-center'>
-                <div className='mr2'>
-                  <FontIcon className='material-icons' color='#999'>date_range</FontIcon>
-                </div>
-                <DatePicker
-                  minDate={now}
-                  onChange={(evt, val) => {
-                    this.setState({ attrDate: val })
-                  }}
-                  formatDate={date => moment(date).format('D MMM YYYY')}
-                  value={attrDate}
-                  hintText='Date'
-                  textFieldStyle={displayTextFieldStyle}
-                />
-              </div>
-              <div className='flex-grow flex items-center ml2'>
-                {showTime && (
+            {!hideDateRow && infoItemLabel('Deadline')}
+            {!hideDateRow && (
+              <div className='flex'>
+                <div className='flex-grow flex items-center'>
                   <div className='mr2'>
-                    <FontIcon className='material-icons' color='#999'>access_time</FontIcon>
+                    <FontIcon className='material-icons' color='#999'>date_range</FontIcon>
                   </div>
-                )}
-                {showTime && (
-                  <TimePicker
-                    hintText='Time'
-                    value={attrTime}
+                  <DatePicker
+                    minDate={now}
                     onChange={(evt, val) => {
-                      this.setState({ attrTime: val })
+                      this.setState({ attrDate: val })
                     }}
+                    formatDate={date => moment(date).format('D MMM YYYY')}
+                    value={attrDate}
+                    hintText='Date'
                     textFieldStyle={displayTextFieldStyle}
                   />
-                )}
+                </div>
+                <div className='flex-grow flex items-center ml2'>
+                  {showTime && (
+                    <div className='mr2'>
+                      <FontIcon className='material-icons' color='#999'>access_time</FontIcon>
+                    </div>
+                  )}
+                  {showTime && (
+                    <TimePicker
+                      hintText='Time'
+                      value={attrTime}
+                      onChange={(evt, val) => {
+                        this.setState({ attrTime: val })
+                      }}
+                      textFieldStyle={displayTextFieldStyle}
+                    />
+                  )}
+                </div>
               </div>
-            </div>
+            )}
           </div>
           <div>
             <RaisedButton

--- a/imports/ui/dialogs/case-target-attr-dialog.jsx
+++ b/imports/ui/dialogs/case-target-attr-dialog.jsx
@@ -1,0 +1,174 @@
+// @flow
+import * as React from 'react'
+import RaisedButton from 'material-ui/RaisedButton'
+import IconButton from 'material-ui/IconButton'
+import Dialog from 'material-ui/Dialog'
+import {
+  closeDialogButtonStyle,
+  modalBodyStyle,
+  modalCustomContentStyle,
+  customTitleStyle
+} from './generic-dialog.mui-styles'
+import FontIcon from 'material-ui/FontIcon'
+import moment from 'moment'
+import { infoItemLabel } from '../util/static-info-rendering'
+import EditableItem from '../components/editable-item'
+import DatePicker from 'material-ui/DatePicker'
+import TimePicker from 'material-ui/TimePicker'
+
+type Props = {
+  show: boolean,
+  attrName: string,
+  initialValue?: string,
+  initialDate?: Date,
+  onCancel: () => void,
+  showTime?: boolean,
+  onSubmit: (value: string, date: Date) => void
+}
+
+type State = {
+  attrValue: string,
+  attrDate: ?Date,
+  attrTime: any,
+  isEditing: boolean
+}
+
+const displayTextFieldStyle = {
+  width: 'fit-content',
+  color: '#999'
+}
+
+export default class CaseTargetAttrDialog extends React.Component<Props, State> {
+  state = {
+    attrValue: '',
+    attrDate: null,
+    attrTime: null,
+    isEditing: false
+  }
+
+  componentDidMount () {
+    const { initialValue, initialDate } = this.props
+    let initialTime
+    if (initialDate) {
+      const hours = initialDate.getHours()
+      const minutes = initialDate.getMinutes()
+      initialTime = moment().add(hours, 'hours').add(minutes, 'minutes').toDate()
+    }
+    this.setState({
+      attrValue: initialValue,
+      attrDate: initialDate,
+      attrTime: initialTime,
+      isEditing: !!initialValue || !!initialDate
+    })
+  }
+
+  componentDidUpdate (prevProps: Props) {
+    const { initialValue, initialDate } = this.props
+    const stateMutations = {}
+    if (prevProps.initialValue !== initialValue) {
+      Object.assign(stateMutations, {
+        attrValue: initialValue
+      })
+    }
+    if ((!prevProps.initialDate && !!initialDate) || (
+      prevProps.initialDate && initialDate && prevProps.initialDate.getTime() !== initialDate.getTime())
+    ) {
+      const hours = initialDate.getHours()
+      const minutes = initialDate.getMinutes()
+      Object.assign(stateMutations, {
+        attrDate: initialDate,
+        attrTime: moment().add(hours, 'hours').add(minutes, 'minutes').toDate()
+      })
+    }
+
+    if (Object.keys(stateMutations).length > 0) {
+      this.setState({ ...stateMutations, isEditing: true })
+    }
+  }
+
+  handleSubmitClicked = () => {
+    const { attrValue, attrDate, attrTime } = this.state
+    const hours = attrTime ? attrTime.getHours() : 0
+    const minutes = attrTime ? attrTime.getMinutes() : 0
+    const finalDateTime = moment(attrDate)
+    finalDateTime.add(hours, 'hours').add(minutes, 'minutes')
+    this.props.onSubmit(attrValue, finalDateTime.toDate())
+  }
+
+  render () {
+    const { show, onCancel, attrName, showTime } = this.props
+    const { attrValue, attrDate, attrTime, isEditing } = this.state
+    const now = new Date()
+    return (
+      <Dialog
+        open={show}
+        title={(isEditing ? 'Edit ' : 'Create ') + attrName}
+        bodyStyle={modalBodyStyle}
+        contentStyle={modalCustomContentStyle}
+        titleStyle={customTitleStyle}
+        onRequestClose={onCancel}
+      >
+        <div className='absolute top-1 right-1'>
+          <IconButton onClick={onCancel}>
+            <FontIcon className='material-icons' style={closeDialogButtonStyle}>close</FontIcon>
+          </IconButton>
+        </div>
+        <div className='flex flex-column h6'>
+          <EditableItem
+            isMultiLine
+            label={attrName}
+            onEdit={val => { this.setState({ attrValue: val }) }}
+            currentValue={attrValue}
+          />
+          <div className='mt3 flex-grow'>
+            {infoItemLabel('Deadline')}
+            <div className='flex'>
+              <div className='flex-grow flex items-center'>
+                <div className='mr2'>
+                  <FontIcon className='material-icons' color='#999'>date_range</FontIcon>
+                </div>
+                <DatePicker
+                  minDate={now}
+                  onChange={(evt, val) => {
+                    this.setState({ attrDate: val })
+                  }}
+                  formatDate={date => moment(date).format('D MMM YYYY')}
+                  value={attrDate}
+                  hintText='Date'
+                  textFieldStyle={displayTextFieldStyle}
+                />
+              </div>
+              <div className='flex-grow flex items-center ml2'>
+                {showTime && (
+                  <div className='mr2'>
+                    <FontIcon className='material-icons' color='#999'>access_time</FontIcon>
+                  </div>
+                )}
+                {showTime && (
+                  <TimePicker
+                    hintText='Time'
+                    value={attrTime}
+                    onChange={(evt, val) => {
+                      this.setState({ attrTime: val })
+                    }}
+                    textFieldStyle={displayTextFieldStyle}
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+          <div>
+            <RaisedButton
+              fullWidth
+              primary
+              disabled={!attrValue || !attrDate || (!attrTime && showTime)}
+              onClick={this.handleSubmitClicked}
+            >
+              <span className='fw5 white'>{isEditing ? 'Save Changes' : `Add ${attrName}`}</span>
+            </RaisedButton>
+          </div>
+        </div>
+      </Dialog>
+    )
+  }
+}

--- a/imports/ui/dialogs/case-target-attr-dialog.jsx
+++ b/imports/ui/dialogs/case-target-attr-dialog.jsx
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import RaisedButton from 'material-ui/RaisedButton'
 import IconButton from 'material-ui/IconButton'
-import Dialog from 'material-ui/Dialog'
+import HeightHackDialog from './height-hack-dialog'
 import {
   closeDialogButtonStyle,
   modalBodyStyle,
@@ -100,7 +100,8 @@ export default class CaseTargetAttrDialog extends React.Component<Props, State> 
     const { attrValue, attrDate, attrTime, isEditing } = this.state
     const now = new Date()
     return (
-      <Dialog
+      <HeightHackDialog
+        padding={100}
         open={show}
         title={(isEditing ? 'Edit ' : 'Create ') + attrName}
         bodyStyle={modalBodyStyle}
@@ -168,7 +169,7 @@ export default class CaseTargetAttrDialog extends React.Component<Props, State> 
             </RaisedButton>
           </div>
         </div>
-      </Dialog>
+      </HeightHackDialog>
     )
   }
 }

--- a/imports/ui/dialogs/height-hack-dialog.jsx
+++ b/imports/ui/dialogs/height-hack-dialog.jsx
@@ -1,0 +1,69 @@
+// @flow
+// global setTimeout
+import * as React from 'react'
+import Dialog from 'material-ui/Dialog'
+import { modalBodyStyle } from './generic-dialog.mui-styles'
+
+type Props = {
+  padding: number,
+  title?: ?string,
+  titleStyle?: Object,
+  modal?: boolean,
+  open: boolean,
+  bodyStyle?: Object,
+  contentStyle?: Object,
+  children: React.Node,
+  onHeightChange?: (val: number) => void,
+  onRequestClose: (cb: () => void) => void
+}
+type State = {
+  currMaxHeight: number
+}
+
+export default class HeightHackDialog extends React.Component<Props, State> {
+  constructor (props: Props) {
+    super(props)
+    this.state = {
+      currMaxHeight: window.innerHeight - props.padding
+    }
+    setTimeout(() => {
+      props.onHeightChange && props.onHeightChange(window.innerHeight - props.padding)
+    })
+    window.addEventListener('resize', this.handleWindowResize)
+  }
+
+  componentWillUnmount () {
+    window.removeEventListener('resize', this.handleWindowResize)
+  }
+
+  handleWindowResize = () => {
+    const { onHeightChange } = this.props
+    this.setState({
+      currMaxHeight: window.innerHeight - this.props.padding
+    })
+    onHeightChange && onHeightChange(window.innerHeight - this.props.padding)
+  }
+
+  render () {
+    const {
+      children,
+      title,
+      titleStyle,
+      contentStyle,
+      bodyStyle = {},
+      modal = false,
+      open,
+      onRequestClose
+    } = this.props
+    const { currMaxHeight } = this.state
+    return (
+      <Dialog
+        {...{ title, titleStyle, contentStyle, modal, open, onRequestClose }}
+        bodyStyle={Object.assign({ maxHeight: currMaxHeight }, bodyStyle)}
+        autoDetectWindowHeight={false}
+      >
+        {children}
+      </Dialog>
+    )
+  }
+}

--- a/imports/ui/dialogs/height-hack-dialog.jsx
+++ b/imports/ui/dialogs/height-hack-dialog.jsx
@@ -2,7 +2,6 @@
 // global setTimeout
 import * as React from 'react'
 import Dialog from 'material-ui/Dialog'
-import { modalBodyStyle } from './generic-dialog.mui-styles'
 
 type Props = {
   padding: number,

--- a/imports/ui/dialogs/invite-dialog.jsx
+++ b/imports/ui/dialogs/invite-dialog.jsx
@@ -3,11 +3,11 @@ import { connect } from 'react-redux'
 import { Route } from 'react-router-dom'
 import { replace, goBack } from 'react-router-redux'
 import PropTypes from 'prop-types'
-import Dialog from 'material-ui/Dialog'
 import FontIcon from 'material-ui/FontIcon'
 import CircularProgress from 'material-ui/CircularProgress'
 import RaisedButton from 'material-ui/RaisedButton'
 import ErrorDialog from './error-dialog'
+import HeightHackDialog from './height-hack-dialog'
 import EmailInput from '../components/email-input'
 import UnitRoleSelect from '../components/unit-role-select'
 
@@ -41,10 +41,8 @@ class InviteDialog extends Component {
       isOccupant: false,
       inputErrorModalOpen: false,
       inviteeEmail: '',
-      currMaxHeight: window.innerHeight - DIALOG_PADDING
+      dialogHeight: 400 - DIALOG_PADDING
     }
-
-    window.addEventListener('resize', this.handleWindowResize)
   }
 
   componentDidUpdate () {
@@ -54,16 +52,6 @@ class InviteDialog extends Component {
         this.inputToFocus.focus()
       }
     }, 300)
-  }
-
-  componentWillUnmount () {
-    window.removeEventListener('resize', this.handleWindowResize)
-  }
-
-  handleWindowResize = () => {
-    this.setState({
-      currMaxHeight: window.innerHeight - DIALOG_PADDING
-    })
   }
 
   handleSendInviteClick = () => {
@@ -92,11 +80,13 @@ class InviteDialog extends Component {
       title, additionalOperationText, mainOperationText, onMainOperation, disableMainOperation, linkLabelForNewUser,
       mainOperationSuccessContent, dispatch, isUnitOwner, unitRoleType
     } = this.props
-    const { selectedRole, isOccupant, inputErrorModalOpen, inviteeEmail, currMaxHeight } = this.state
+    const { selectedRole, isOccupant, inputErrorModalOpen, inviteeEmail, dialogHeight } = this.state
     return (
       <Route path={`${basePath}/${relPath}`} children={({ match }) => {
         return (
-          <Dialog
+          <HeightHackDialog
+            onHeightChange={val => this.setState({ dialogHeight: val })}
+            padding={DIALOG_PADDING}
             title={invitationState.loading ? 'Please wait... '
               : (!invitationState.completed && !mainOperationSuccessContent) ? title
                 : null
@@ -105,8 +95,7 @@ class InviteDialog extends Component {
             modal
             open={!!match}
             contentStyle={modalCustomContentStyle}
-            bodyStyle={Object.assign({ maxHeight: currMaxHeight }, modalBodyStyle)}
-            autoDetectWindowHeight={false}
+            bodyStyle={modalBodyStyle}
           >
             <a
               onClick={() => {
@@ -123,7 +112,7 @@ class InviteDialog extends Component {
             <Route exact path={`${basePath}/${relPath}`} render={() => mainOperationSuccessContent
               ? successWrapper(mainOperationSuccessContent)
               : (
-                <div className='mt2 flex flex-column flex-grow' style={{ maxHeight: currMaxHeight - DIALOG_INTERNAL_PADDING }}>
+                <div className='mt2 flex flex-column flex-grow' style={{ maxHeight: dialogHeight - DIALOG_INTERNAL_PADDING }}>
                   {selectControlsRenderer({
                     users: potentialInvitees,
                     inputRefFn: el => { this.inputToFocus = el }
@@ -217,7 +206,7 @@ class InviteDialog extends Component {
                 </div>
               )} />
             )}
-          </Dialog>
+          </HeightHackDialog>
         )
       }} />
     )


### PR DESCRIPTION
Resolves #853

There are two limitations that keep this PR from being implemented exactly like the design sketches. The first is that the hours and minutes display and editing is disabled for "Next Steps Deadline" as the BZ API is blocking setting a datetime to that field. That will need to be resolved with a configuration/schema change on the BZ side, and then it could be re-enabled on the UI.

The second is that the bottom drawer menu that opens after clicking an icon in the top right corner is not available with the version of the UI library we're currently using. It is available with the newest version of the library, but an upgrade requires a migration which is quite non-trivial.

![Screenshot from 2019-08-14 19-14-30](https://user-images.githubusercontent.com/2662819/63017037-ca1a4780-bec7-11e9-94d8-169a216295d3.png)
![Screenshot from 2019-08-14 19-10-25](https://user-images.githubusercontent.com/2662819/63017048-d0a8bf00-bec7-11e9-8ba3-425ad028abfd.png)
![Screenshot from 2019-08-14 19-10-41](https://user-images.githubusercontent.com/2662819/63017050-d0a8bf00-bec7-11e9-9eac-3dbe4c6401e1.png)
![Screenshot from 2019-08-14 19-10-59](https://user-images.githubusercontent.com/2662819/63017052-d1415580-bec7-11e9-84a2-4860fe14ffa0.png)
![Screenshot from 2019-08-14 19-11-21](https://user-images.githubusercontent.com/2662819/63017054-d1415580-bec7-11e9-9d62-910ff7c71421.png)
![Screenshot from 2019-08-14 19-11-31](https://user-images.githubusercontent.com/2662819/63017055-d1415580-bec7-11e9-81b9-0520f897ed3f.png)
![Screenshot from 2019-08-14 19-12-04](https://user-images.githubusercontent.com/2662819/63017056-d1d9ec00-bec7-11e9-93a4-edc43f130374.png)
![Screenshot from 2019-08-14 19-12-25](https://user-images.githubusercontent.com/2662819/63017057-d1d9ec00-bec7-11e9-91ad-debf59942956.png)
