### PR TITLE
feat: select all text on focus; fix empty val not restored after reopen

### DIFF
--- a/imports/ui/components/editable-item.jsx
+++ b/imports/ui/components/editable-item.jsx
@@ -34,7 +34,7 @@ export default class EditableItem extends Component {
     this.props.onEdit(value)
   }
   render () {
-    const { label, isMultiLine, selectionList, disabled, name, underlineShow, inpRef, rowsMax } = this.props
+    const { label, isMultiLine, selectionList, disabled, name, underlineShow, inpRef, rowsMax, onFocus } = this.props
     const { value } = this.state
 
     const optionalAttrs = {}
@@ -56,6 +56,7 @@ export default class EditableItem extends Component {
           value={value}
           inpRef={inpRef}
           onChange={({ target: { value } }) => this.handleEdit(value)}
+          onFocus={onFocus}
           {...optionalAttrs}
         />
       )
@@ -90,6 +91,7 @@ EditableItem.propTypes = {
   selectionList: PropTypes.array,
   disabled: PropTypes.bool,
   rowsMax: PropTypes.number,
+  onFocus: PropTypes.func, // relevant only if "selectionList" is undefined
   inpRef: PropTypes.func, // relevant only if "selectionList" is undefined
   underlineShow: PropTypes.bool // relevant only if "selectionList" is undefined
 }

--- a/imports/ui/dialogs/case-target-attr-dialog.jsx
+++ b/imports/ui/dialogs/case-target-attr-dialog.jsx
@@ -142,7 +142,11 @@ export default class CaseTargetAttrDialog extends React.Component<Props, State> 
             onEdit={val => { this.setState({ attrValue: val }) }}
             currentValue={attrValue}
             inpRef={el => { this.textInput = el }}
-            onFocus={() => this.textInput && this.textInput.getInputNode().setSelectionRange(0, attrValue.length)}
+            onFocus={() => {
+              setTimeout(() => {
+                this.textInput && this.textInput.getInputNode().setSelectionRange(0, attrValue.length)
+              }, 20)
+            }}
             rowsMax={3}
           />
           <div className='mt3 flex-grow'>

--- a/imports/ui/dialogs/case-target-attr-dialog.jsx
+++ b/imports/ui/dialogs/case-target-attr-dialog.jsx
@@ -48,6 +48,12 @@ export default class CaseTargetAttrDialog extends React.Component<Props, State> 
     hideDateRow: false
   }
 
+  textInput: ?{
+    getInputNode: () => {
+      setSelectionRange: (start: number, end: number) => void
+    }
+  } = null
+
   componentDidMount () {
     const { initialValue, initialDate } = this.props
     let initialTime
@@ -65,15 +71,18 @@ export default class CaseTargetAttrDialog extends React.Component<Props, State> 
   }
 
   componentDidUpdate (prevProps: Props) {
-    const { initialValue, initialDate } = this.props
+    const { initialValue, initialDate, show } = this.props
     const stateMutations = {}
-    if (prevProps.initialValue !== initialValue) {
+    const isClosing = !show && prevProps.show
+    if (prevProps.initialValue !== initialValue || isClosing) {
       Object.assign(stateMutations, {
         attrValue: initialValue
       })
     }
-    if ((!prevProps.initialDate && !!initialDate) || (
-      prevProps.initialDate && initialDate && prevProps.initialDate.getTime() !== initialDate.getTime())
+    if (
+      (!prevProps.initialDate && !!initialDate) ||
+      (prevProps.initialDate && initialDate && prevProps.initialDate.getTime() !== initialDate.getTime()) ||
+      (isClosing && initialDate)
     ) {
       const hours = initialDate.getHours()
       const minutes = initialDate.getMinutes()
@@ -132,6 +141,8 @@ export default class CaseTargetAttrDialog extends React.Component<Props, State> 
             label={attrName}
             onEdit={val => { this.setState({ attrValue: val }) }}
             currentValue={attrValue}
+            inpRef={el => { this.textInput = el }}
+            onFocus={() => this.textInput && this.textInput.getInputNode().setSelectionRange(0, attrValue.length)}
             rowsMax={3}
           />
           <div className='mt3 flex-grow'>


### PR DESCRIPTION
Resolves #822  (but in an alternative way)
The entire field's contents are selected when the field is focused, so any character typed would remove the existing text, unless another tap is made on the field to place the caret in a specific location.
Also fixes an issue where the solution/next steps value wouldn't be restored if the value was changed, not saved, and the dialog was reopened.
![image](https://user-images.githubusercontent.com/2662819/63608193-f429e300-c606-11e9-9548-fc721a2654bd.png)

