### PR TITLE
Fix invalidation to use correct credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
           - AWS_ACCESS_KEY_ID=$AWS_192458993663_ID
             AWS_SECRET_ACCESS_KEY=$AWS_192458993663_SECRET
             ./deploy.sh -p
-          - aws cloudfront create-invalidation
+          - AWS_ACCESS_KEY_ID=$AWS_192458993663_ID AWS_SECRET_ACCESS_KEY=$AWS_192458993663_SECRET aws cloudfront create-invalidation
             --distribution-id E173XT6X8V4A18 --paths '/*'
         on:
           tags: true


### PR DESCRIPTION
https://github.com/unee-t/frontend/issues/859
This might not work since deploys can timeout or fail before
invalidation is ever run. Or worse invalidation happens before the app
rolls out changes, leading the previous app to be effectively cached,
and not the new one.