### PR TITLE
Reordered depedencies for tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ USER node:node
 WORKDIR /src
 COPY --chown=node:node . .
 
+RUN npm install
+
 RUN meteor npm install --production
 RUN meteor build --architecture os.linux.x86_64 --directory /bundle
 RUN cd /bundle/bundle/programs/server && npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ USER node:node
 WORKDIR /src
 COPY --chown=node:node . .
 
-RUN npm install
-
 RUN meteor npm install --production
 RUN meteor build --architecture os.linux.x86_64 --directory /bundle
 RUN cd /bundle/bundle/programs/server && npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ USER node:node
 WORKDIR /src
 COPY --chown=node:node . .
 
-RUN meteor npm install --production
+RUN meteor npm install
 RUN meteor build --architecture os.linux.x86_64 --directory /bundle
 RUN cd /bundle/bundle/programs/server && npm install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,6 @@ USER node:node
 WORKDIR /src
 COPY --chown=node:node . .
 
-# Workaround https://github.com/CyCoreSystems/go-meteor/issues/6
-RUN meteor npm install --save postcss-easy-import
-
 RUN meteor npm install --production
 RUN meteor build --architecture os.linux.x86_64 --directory /bundle
 RUN cd /bundle/bundle/programs/server && npm install

--- a/imports/api/rest/put-pending-invitations.js
+++ b/imports/api/rest/put-pending-invitations.js
@@ -3,9 +3,8 @@ import { invite } from '../../util/email-invite'
 import { Meteor } from 'meteor/meteor'
 
 import { reloadCaseFields } from '../cases'
-import UnitRolesData from '../unit-roles-data'
+import UnitRolesData, { defaultRoleVisibility } from '../unit-roles-data'
 import { logger } from '../../util/logger'
-import { defaultRoleVisibility } from '../units'
 
 export default (req, res) => {
   if (req.query.accessToken !== process.env.API_ACCESS_TOKEN) {

--- a/imports/migrations/13_add_role_visibility_to_all_members.js
+++ b/imports/migrations/13_add_role_visibility_to_all_members.js
@@ -1,6 +1,5 @@
 import { Migrations } from 'meteor/percolate:migrations'
-import UnitRolesData from '../api/unit-roles-data'
-import { defaultRoleVisibility } from '../api/units'
+import UnitRolesData, { defaultRoleVisibility } from '../api/unit-roles-data'
 
 Migrations.add({
   version: 13,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2694,7 +2694,7 @@
         "process": "^0.11.9",
         "punycode": "^1.4.1",
         "querystring-es3": "^0.2.1",
-        "readable-stream": "readable-stream@git+https://github.com/meteor/readable-stream.git#2e9112d7d31a2af6e0682db0e18679b1e5fd4694",
+        "readable-stream": "git+https://github.com/meteor/readable-stream.git#2e9112d7d31a2af6e0682db0e18679b1e5fd4694",
         "stream-browserify": "^2.0.1",
         "string_decoder": "^1.0.1",
         "timers-browserify": "^1.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -204,9 +204,9 @@
       }
     },
     "agent-base": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha1-2J5ZmfeXh1Z0wH2H8mD8Qeg+jKk=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
@@ -329,9 +329,9 @@
       "dev": true
     },
     "async-limiter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
     },
     "asynckit": {
@@ -535,9 +535,9 @@
       }
     },
     "buffer-from": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-      "integrity": "sha1-h/yqOimDWOCt5uRCz86EB0DRrQQ=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
     "builtin-modules": {
@@ -2021,23 +2021,29 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha1-UVUpcPoE1yPgTFbQQXjD+SWSu8A=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
+      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
       "dev": true,
       "requires": {
-        "agent-base": "^4.1.0",
+        "agent-base": "^4.3.0",
         "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
@@ -2688,7 +2694,7 @@
         "process": "^0.11.9",
         "punycode": "^1.4.1",
         "querystring-es3": "^0.2.1",
-        "readable-stream": "git+https://github.com/meteor/readable-stream.git#2e9112d7d31a2af6e0682db0e18679b1e5fd4694",
+        "readable-stream": "readable-stream@git+https://github.com/meteor/readable-stream.git#2e9112d7d31a2af6e0682db0e18679b1e5fd4694",
         "stream-browserify": "^2.0.1",
         "string_decoder": "^1.0.1",
         "timers-browserify": "^1.4.2",
@@ -3247,9 +3253,9 @@
       }
     },
     "mime": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-      "integrity": "sha1-sWIcVNY7l8R9PP5/chX31kUXw2k=",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
       "dev": true
     },
     "mime-db": {
@@ -4077,19 +4083,19 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "puppeteer": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.6.0.tgz",
-      "integrity": "sha512-88epdIp3lw0LxI+sIHgdgZdq/u5zRnzgU2vJGvcyuGqHQrtRUeICTexTyT1KoKhTGG0mAKFRV9c7IJ179agm7A==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.20.0.tgz",
+      "integrity": "sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==",
       "dev": true,
       "requires": {
-        "debug": "^3.1.0",
+        "debug": "^4.1.0",
         "extract-zip": "^1.6.6",
         "https-proxy-agent": "^2.2.1",
         "mime": "^2.0.3",
-        "progress": "^2.0.0",
+        "progress": "^2.0.1",
         "proxy-from-env": "^1.0.0",
         "rimraf": "^2.6.1",
-        "ws": "^5.1.1"
+        "ws": "^6.1.0"
       },
       "dependencies": {
         "concat-stream": {
@@ -4105,12 +4111,12 @@
           }
         },
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
         "extract-zip": {
@@ -4133,13 +4139,25 @@
               "requires": {
                 "ms": "2.0.0"
               }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
             }
           }
         },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
         "progress": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-          "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+          "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
           "dev": true
         }
       }
@@ -5702,9 +5720,9 @@
       }
     },
     "ws": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha1-3/7xSGa46NyRM1glFNG++vlumA8=",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
       "dev": true,
       "requires": {
         "async-limiter": "~1.0.0"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "postcss-modules-local-by-default": "^1.2.0",
     "postcss-modules-scope": "^1.1.0",
     "postcss-nested": "^1.0.1",
-    "puppeteer": "^1.6.0",
+    "puppeteer": "^1.20.0",
     "react-addons-test-utils": "^15.6.0",
     "react-test-renderer": "^15.6.1",
     "snazzy": "^7.0.0",


### PR DESCRIPTION
@kaihendry I moved some code around to create a uni-directional dependency between two major modules, as for some reason, Puppeteer can't resolve code with bi-directional dependency as well as the Meteor runtime. Tests are running fine after these changes,